### PR TITLE
Bounty #327: Add shielded token operations tutorial and tests

### DIFF
--- a/bounties/327-shielded-token-operations/.gitignore
+++ b/bounties/327-shielded-token-operations/.gitignore
@@ -1,0 +1,17 @@
+# This file is part of midnightntwrk/contributor-hub.
+# Copyright (C) 2025 Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+node_modules/
+src/managed/

--- a/bounties/327-shielded-token-operations/LICENSE
+++ b/bounties/327-shielded-token-operations/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/bounties/327-shielded-token-operations/README.md
+++ b/bounties/327-shielded-token-operations/README.md
@@ -1,20 +1,3 @@
-<!--
-This file is part of midnightntwrk/contributor-hub.
-Copyright (C) 2025 Midnight Foundation
-SPDX-License-Identifier: Apache-2.0
-Licensed under the Apache License, Version 2.0 (the "License");
-You may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 # Bounty 327: Shielded Token Operations
 
 This package contains the code artifact for issue #327, covering a Compact

--- a/bounties/327-shielded-token-operations/README.md
+++ b/bounties/327-shielded-token-operations/README.md
@@ -1,0 +1,60 @@
+<!--
+This file is part of midnightntwrk/contributor-hub.
+Copyright (C) 2025 Midnight Foundation
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Bounty 327: Shielded Token Operations
+
+This package contains the code artifact for issue #327, covering a Compact
+shielded-token lifecycle contract plus a Vitest suite for mint, transfer, burn,
+change handling, nonce evolution, and the Merkle timing rule.
+
+## Contents
+
+- `src/shielded-token-lifecycle.compact` - Compact contract with shielded mint,
+  committed send, committed burn, fresh burn, and atomic mint-and-send circuits.
+- `src/witnesses.ts` - TypeScript witness implementation for local nonce seed
+  management.
+- `src/model/shielded-token-model.ts` - Test model mirroring the contract-facing
+  shielded token flow.
+- `test/shielded-token-lifecycle.test.ts` - Vitest coverage for normal flows and
+  edge cases.
+- `TUTORIAL.md` - Written tutorial for the bounty.
+
+## Setup
+
+```bash
+npm install
+npm run typecheck
+npm test
+```
+
+To compile the Compact contract, install the Midnight Compact toolchain and run:
+
+```bash
+npm run compact
+```
+
+On Windows, ensure the Midnight `compact` tool is earlier on `PATH` than
+`C:\Windows\System32\compact.exe`, or run the Compact toolchain from WSL. The
+Windows system `compact.exe` is a filesystem compression utility, not the
+Midnight compiler.
+
+## Notes
+
+The test model deliberately distinguishes `ShieldedCoinInfo` from
+`QualifiedShieldedCoinInfo`. A fresh coin can be spent in the same transaction
+with `sendImmediateShielded`, but a later `sendShielded` call requires a Merkle
+tree index (`mtIndex`) after the coin has been committed on-chain.

--- a/bounties/327-shielded-token-operations/TUTORIAL.md
+++ b/bounties/327-shielded-token-operations/TUTORIAL.md
@@ -1,71 +1,182 @@
-<!--
-This file is part of midnightntwrk/contributor-hub.
-Copyright (C) 2025 Midnight Foundation
-SPDX-License-Identifier: Apache-2.0
-Licensed under the Apache License, Version 2.0 (the "License");
-You may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Build shielded token mint, transfer, and burn flows in Compact
 
-http://www.apache.org/licenses/LICENSE-2.0
+Shielded tokens let Midnight applications move value while keeping sensitive
+transaction details private. In this tutorial, you will build a small Compact
+project that mints shielded value, transfers it, burns it, and verifies the
+full lifecycle with a Vitest test suite.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
+The core idea is simple but important: a newly minted shielded coin is not yet a
+committed ledger coin. Fresh coins use `ShieldedCoinInfo` and can be spent
+immediately with `sendImmediateShielded`. Coins that already exist in the ledger
+use `QualifiedShieldedCoinInfo`, which includes the Merkle tree index required
+by `sendShielded`.
 
-# Shielded Token Operations: Mint, Transfer, Burn, and Tests
+You will use that distinction to build three practical flows: minting to the
+current contract, transferring committed value to a user, and burning both fresh
+and committed shielded value. Along the way, you will also handle change outputs
+and nonce derivation, two details that matter in real wallet and DApp code.
 
-This tutorial walks through a small Compact contract that demonstrates a full
-shielded token lifecycle on Midnight: minting a shielded coin, spending it to a
-recipient, returning change, burning shielded value, and testing the edge cases
-that matter for production code. The companion code lives in this directory and
-is organized as a minimal package that can be installed, typechecked, tested
-with Vitest, and compiled with the Midnight Compact toolchain.
+By the end of this tutorial, you will:
 
-The examples focus on contract-owned shielded coins. A contract mints a shielded
-token to itself, later spends the committed coin with `sendShielded`, and uses
-`ShieldedSendResult.change` to keep track of any remaining value. The same
-contract also demonstrates the immediate path: when a coin is created and spent
-inside the same transaction, it is a `ShieldedCoinInfo`, not a
-`QualifiedShieldedCoinInfo`, so the correct helper is `sendImmediateShielded`.
-This distinction is the main trap in this topic.
+- Create a Compact contract that mints shielded tokens to itself.
+- Use `evolveNonce` to derive mint nonces safely.
+- Transfer committed shielded coins with `sendShielded`.
+- Burn committed and freshly minted coins with `shieldedBurnAddress`.
+- Use `sendImmediateShielded` for coins created in the same transaction.
+- Write Vitest tests for minting, transfers, burns, change, nonce reuse, and the
+  Merkle timing rule.
 
-## Project shape
+## Prerequisites
 
-The package contains four important files:
+You need:
 
-- `src/shielded-token-lifecycle.compact` contains the Compact circuits.
-- `src/witnesses.ts` implements local private state for nonce seed management.
-- `src/model/shielded-token-model.ts` mirrors the shielded-token rules for
-  deterministic unit tests.
-- `test/shielded-token-lifecycle.test.ts` covers mint, transfer, burn, change,
-  nonce evolution, and Merkle timing.
+- Node.js 20 or newer.
+- npm.
+- The Midnight Compact toolchain.
+- Basic TypeScript knowledge.
+- Basic familiarity with Compact circuits and ledgers.
 
-Install the package and run the tests:
+Install or update the Compact toolchain from the Midnight documentation, then
+check that the command is available:
 
 ```bash
-npm install
-npm run typecheck
-npm test
+compact check
 ```
 
-Compile the Compact contract after installing the Midnight Compact toolchain:
+Expected result:
+
+```text
+compact: Latest version available: ...
+```
+
+On Windows, run the Compact toolchain from WSL or make sure the Midnight
+`compact` binary appears before `C:\Windows\System32\compact.exe` in your
+`PATH`. Windows also has a system command named `compact`, and that command is
+not the Midnight compiler.
+
+## What you will build
+
+The finished demo project has this structure:
+
+```text
+shielded-token-operations/
+|-- package.json
+|-- tsconfig.json
+|-- src/
+|   |-- shielded-token-lifecycle.compact
+|   |-- witnesses.ts
+|   `-- model/
+|       `-- shielded-token-model.ts
+`-- test/
+    `-- shielded-token-lifecycle.test.ts
+```
+
+The Compact file contains the contract. The witness file manages local nonce
+state. The TypeScript model gives you deterministic tests without needing a live
+node. The Vitest file proves the flows and catches the mistakes developers tend
+to make when they mix fresh and committed shielded coins.
+
+## Part 0: Choose the right shielded API
+
+Before writing code, map each operation to the correct standard library helper.
+Most bugs in shielded token examples come from choosing the right idea but the
+wrong helper.
+
+Use `mintShieldedToken` when the contract creates a new shielded token. It
+returns `ShieldedCoinInfo`, which describes a fresh output from the current
+transaction.
+
+Use `sendImmediateShielded` when that fresh output is spent in the same
+transaction. This is the right tool for atomic flows such as mint-and-send or
+mint-and-burn.
+
+Use `sendShielded` when the coin already exists in the ledger. This requires
+`QualifiedShieldedCoinInfo`, not plain `ShieldedCoinInfo`, because the committed
+coin must include its Merkle tree position.
+
+Use `shieldedBurnAddress()` when the send target should destroy the shielded
+value. Burning is not a separate token primitive in this example; it is a send
+to a special recipient.
+
+Keep this decision table nearby while building:
+
+```text
+Operation                      Input coin type              Helper
+Mint new shielded value        none                         mintShieldedToken
+Spend fresh minted value       ShieldedCoinInfo             sendImmediateShielded
+Spend later committed value    QualifiedShieldedCoinInfo    sendShielded
+Burn fresh minted value        ShieldedCoinInfo             sendImmediateShielded + shieldedBurnAddress
+Burn committed value           QualifiedShieldedCoinInfo    sendShielded + shieldedBurnAddress
+```
+
+The tutorial code follows this table exactly. If you change the API shape later,
+re-run the tests that check immediate sends and Merkle timing.
+
+## Part 1: Create the package
+
+Create a folder for the demo project:
 
 ```bash
-npm run compact
+mkdir shielded-token-operations
+cd shielded-token-operations
 ```
 
-On Windows, be careful with the command name. Windows ships a system utility
-named `compact.exe` for filesystem compression. If that binary appears before
-the Midnight toolchain in `PATH`, `npm run compact` will call the wrong program.
-Using WSL or adjusting `PATH` avoids that collision.
+Initialize the package:
 
-## Compact contract structure
+```bash
+npm init -y
+```
 
-The contract starts like current Midnight examples: no wrapper object, a language
-version pragma, and an import of the standard library.
+Install the test and TypeScript dependencies:
+
+```bash
+npm install --save-dev typescript vitest @types/node
+```
+
+Update `package.json` with these scripts:
+
+```json
+{
+  "scripts": {
+    "compact": "compact compile src/shielded-token-lifecycle.compact ./src/managed/shielded-token-lifecycle",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}
+```
+
+Create `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}
+```
+
+This setup lets you run fast local tests while still keeping a direct Compact
+compile command for the smart contract.
+
+## Part 2: Write the Compact contract
+
+Create the source folder:
+
+```bash
+mkdir -p src
+touch src/shielded-token-lifecycle.compact
+```
+
+Start the contract with the language pragma, the standard library import, and
+two public ledger fields:
 
 ```compact
 pragma language_version >= 0.20;
@@ -80,44 +191,22 @@ constructor() {
 }
 ```
 
-`mintedOperations` is a simple counter so tests and users can see that a minting
-path was executed. `totalBurned` records the amount that the contract has sent
-to the shielded burn address. This is not meant to replace chain accounting, but
-it is useful application state for a tutorial because it makes the burn path
-observable.
+`mintedOperations` is a simple counter used by the example. `totalBurned`
+records the amount this contract has intentionally sent to the shielded burn
+address.
 
-The contract also declares one witness:
+Next, add a witness for local nonce seed management:
 
 ```compact
 witness localNonceSeed(): Bytes<32>;
 ```
 
-The witness returns a private local seed. The Compact circuit can combine that
-seed with a public index by calling `evolveNonce(index, nonce)`. This pattern
-keeps nonce generation deterministic while making accidental nonce reuse easier
-to avoid. A production app should persist its private state and should never
-reset the seed/index pair in a way that reuses the same nonce for the same token
-domain.
+The witness value is private state supplied by the TypeScript layer. The
+contract will combine it with a public nonce index using `evolveNonce`.
 
-## Minting shielded tokens
+## Part 3: Mint shielded tokens
 
-The standard library function used for minting is:
-
-```compact
-mintShieldedToken(
-  domainSep: Bytes<32>,
-  value: Uint<64>,
-  nonce: Bytes<32>,
-  recipient: Either<ZswapCoinPublicKey, ContractAddress>
-): ShieldedCoinInfo
-```
-
-The returned `ShieldedCoinInfo` describes a newly created shielded output. It
-has a `nonce`, `color`, and `value`. The `color` is the token type derived from
-the domain separator and contract address. The `nonce` must be unique for secure
-operation.
-
-The tutorial contract exposes an explicit mint function:
+Add a circuit that mints directly to the current contract:
 
 ```compact
 export circuit mint_to_contract(
@@ -139,13 +228,19 @@ export circuit mint_to_contract(
 }
 ```
 
-The recipient is `right<ZswapCoinPublicKey, ContractAddress>(kernel.self())`,
-which means the shielded output is addressed to the current contract. This is
-the important choice for the rest of the tutorial: the contract can later spend
-that coin after it is committed on-chain and referenced as a
-`QualifiedShieldedCoinInfo`.
+`mintShieldedToken` returns a `ShieldedCoinInfo`. That is a fresh output. It has
+a nonce, color, and value, but it does not have a Merkle index yet.
 
-There is also a nonce-managed mint:
+The recipient is:
+
+```compact
+right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+```
+
+That means the new shielded coin belongs to the current contract. This is useful
+when the contract should later spend the coin after it appears in the ledger.
+
+Now add a second minting circuit that derives its nonce:
 
 ```compact
 export circuit mint_with_local_nonce(
@@ -168,68 +263,15 @@ export circuit mint_with_local_nonce(
 }
 ```
 
-The point is not that every application must use exactly this API. The point is
-that the nonce policy should be explicit. Passing arbitrary nonces from a UI is
-easy to demo and easy to get wrong. Passing an index and deriving the nonce from
-a private seed gives the application a clear place to enforce monotonic use. The
-`disclose(...)` wrapper around the evolved nonce is intentional. Compact tracks
-values derived from witnesses, and a minted coin returns a nonce-derived output.
-By disclosing the evolved nonce, the contract declares that this obfuscated
-derived value may be visible without disclosing the raw witness seed itself.
+`evolveNonce` takes an index and a prior nonce/seed. The `disclose(...)` wrapper
+around the evolved nonce is intentional. Compact treats witness-derived values
+as private by default, and a minted coin returns nonce-derived data. This wrapper
+declares that the derived nonce value may be used in that public-facing result
+without disclosing the raw witness seed.
 
-## TypeScript witness implementation
+## Part 4: Transfer a committed shielded coin
 
-The witness implementation in `src/witnesses.ts` defines the private state shape:
-
-```ts
-export type ShieldedTokenPrivateState = {
-  readonly nonceSeed: Uint8Array;
-  readonly nextNonceIndex: bigint;
-};
-```
-
-It also exports a constructor for the state and a `witnesses` object with a
-`localNonceSeed` implementation:
-
-```ts
-export const witnesses = {
-  localNonceSeed: ({ privateState }) => [
-    {
-      nonceSeed: privateState.nonceSeed,
-      nextNonceIndex: privateState.nextNonceIndex + 1n,
-    },
-    privateState.nonceSeed,
-  ],
-};
-```
-
-The returned tuple follows the generated Compact runtime pattern: first the next
-private state, then the witness value returned to the circuit. The circuit still
-takes a `nonceIndex` parameter. Keeping the index visible in the circuit makes
-tests and callers explicit about which nonce should be used for a mint, while the
-private state gives the UI or service layer a way to track local progress.
-
-## Sending committed shielded coins
-
-The standard library distinguishes fresh shielded coins from committed shielded
-coins. `ShieldedCoinInfo` is a new coin, usually created in the current
-transaction. `QualifiedShieldedCoinInfo` is a coin that already exists in the
-ledger and includes a Merkle tree position:
-
-```compact
-struct QualifiedShieldedCoinInfo {
-  nonce: Bytes<32>;
-  color: Bytes<32>;
-  value: Uint<128>;
-  mtIndex: Uint<64>;
-}
-```
-
-That `mtIndex` is load-bearing. The Merkle index is what lets the transaction
-prove which committed coin is being spent. A fresh output from
-`mintShieldedToken` does not have this index yet.
-
-The committed send circuit therefore accepts a `QualifiedShieldedCoinInfo`:
+Add a committed transfer circuit:
 
 ```compact
 export circuit send_committed(
@@ -248,7 +290,20 @@ export circuit send_committed(
 }
 ```
 
-The result is a `ShieldedSendResult`:
+The input type matters. `sendShielded` spends a `QualifiedShieldedCoinInfo`.
+That type represents an existing shielded coin in the ledger. It includes the
+Merkle tree position:
+
+```compact
+struct QualifiedShieldedCoinInfo {
+  nonce: Bytes<32>;
+  color: Bytes<32>;
+  value: Uint<128>;
+  mtIndex: Uint<64>;
+}
+```
+
+The result type is `ShieldedSendResult`:
 
 ```compact
 struct ShieldedSendResult {
@@ -257,25 +312,17 @@ struct ShieldedSendResult {
 }
 ```
 
-When the input value is larger than the send value, `change` contains a new
-contract-owned `ShieldedCoinInfo`. The application must not forget this value.
-The change output is how the remaining balance continues to exist. If the input
-is exactly consumed, `change` is empty.
+If you send the full input value, `change` is empty. If you send less than the
+input value, `change` contains a new contract-owned shielded coin. Your
+application must keep track of that change output, wait for it to be committed,
+and later spend it as a qualified coin.
 
-Tests should verify both cases. The suite includes one test that sends `35` out
-of a `100` value coin and expects `65` of change, and another that sends exactly
-`100` and expects no change.
+## Part 5: Burn shielded tokens
 
-## Burning shielded value
+Burning is a send to the special burn recipient returned by
+`shieldedBurnAddress()`.
 
-The standard library exposes a special burn recipient:
-
-```compact
-shieldedBurnAddress(): Either<ZswapCoinPublicKey, ContractAddress>
-```
-
-Any shielded coins sent to that address are burned. The committed burn circuit
-is a small variant of the committed send path:
+Add a committed burn circuit:
 
 ```compact
 export circuit burn_committed(
@@ -296,12 +343,11 @@ export circuit burn_committed(
 }
 ```
 
-The burn result can also include change. Burning `40` out of a `90` value coin
-creates a burned output of `40` and a contract-owned change output of `50`. That
-change output must be committed before it can be spent by a later `sendShielded`
-call.
+This works like a committed transfer, except the recipient is the burn address.
+The result can still include change. Burning `40` from a `90` value coin burns
+`40` and returns `50` as change.
 
-Fresh burns use a different helper:
+Now add a fresh burn circuit:
 
 ```compact
 export circuit burn_fresh(
@@ -310,6 +356,9 @@ export circuit burn_fresh(
   mintNonce: Bytes<32>,
   burnValue: Uint<128>
 ): ShieldedSendResult {
+  assert(disclose(mintValue) > 0, "mint amount must be non-zero");
+  assert(disclose(burnValue) > 0, "burn amount must be non-zero");
+
   const coin = mintShieldedToken(
     disclose(domainSep),
     disclose(mintValue),
@@ -331,16 +380,13 @@ export circuit burn_fresh(
 }
 ```
 
-`sendImmediateShielded` is specifically for coins created in the current
-transaction. No Merkle index is required because the coin has not needed to be
-looked up as a previously committed input.
+Use `sendImmediateShielded` here because the coin was created in the same
+transaction. It has not been committed yet, so it cannot be spent with
+`sendShielded`.
 
-## Atomic mint and send
+## Part 6: Add atomic mint and send
 
-The same immediate rule applies to atomic mint-and-send. If the contract mints a
-coin and sends part of it to a user in the same circuit, it should not pretend
-the fresh coin has an existing Merkle position. It can directly call
-`sendImmediateShielded`:
+Atomic mint-and-send is the same fresh-coin pattern. Add this circuit:
 
 ```compact
 export circuit mint_and_send(
@@ -350,6 +396,9 @@ export circuit mint_and_send(
   recipient: ZswapCoinPublicKey,
   sendValue: Uint<128>
 ): ShieldedSendResult {
+  assert(disclose(mintValue) > 0, "mint amount must be non-zero");
+  assert(disclose(sendValue) > 0, "send amount must be non-zero");
+
   const coin = mintShieldedToken(
     disclose(domainSep),
     disclose(mintValue),
@@ -370,59 +419,160 @@ export circuit mint_and_send(
 }
 ```
 
-This circuit is useful for onboarding flows, reward distribution, or any case
-where a contract creates shielded value and immediately passes some of it to a
-recipient. If `mintValue` is larger than `sendValue`, the returned change should
-be kept by the contract and committed before a future committed spend.
+This circuit mints to the contract and immediately sends part or all of the
+fresh coin to a user public key. If `mintValue` is larger than `sendValue`, the
+returned change belongs to the contract.
 
-## Merkle timing pitfall
+## Part 7: Add the TypeScript witness
 
-The most common mistake is trying to spend a freshly minted `ShieldedCoinInfo`
-with `sendShielded` in a later operation without first obtaining its
-`mtIndex`. A coin created in transaction A is only spendable by `sendShielded`
-after transaction A is included and the output can be referenced from the Merkle
-tree. Before that point, it is just a fresh output.
+Create the witness file:
 
-There are three safe paths:
+```bash
+touch src/witnesses.ts
+```
 
-1. Mint now, wait until the coin is committed, then spend it as a
-   `QualifiedShieldedCoinInfo` with `sendShielded`.
-2. Mint and spend inside the same transaction with `sendImmediateShielded`.
-3. Mint and burn inside the same transaction with `sendImmediateShielded` and
-   `shieldedBurnAddress()`.
+Add a private state type and a witness implementation:
 
-The test model enforces this distinction. If a test passes a fresh
-`ShieldedCoinInfo` into `sendShielded`, it throws an error that mentions
-`mtIndex`. The positive committed path calls `commit(coin)` first, which returns
-a `QualifiedShieldedCoinInfo`.
+```ts
+import { createHash } from "node:crypto";
 
-## Test suite design
+export type ShieldedTokenPrivateState = {
+  readonly nonceSeed: Uint8Array;
+  readonly nextNonceIndex: bigint;
+};
 
-The Vitest suite uses a deterministic TypeScript model rather than talking to a
-live network. This makes the tests fast and focused on lifecycle semantics. The
-model is intentionally shaped like the Compact standard library types:
+type WitnessContext<PrivateState> = {
+  readonly privateState: PrivateState;
+};
 
-- `ShieldedCoinInfo` has `nonce`, `color`, `value`, and a test-only recipient.
-- `QualifiedShieldedCoinInfo` extends it with `mtIndex`.
-- `ShieldedSendResult` has `sent` and nullable `change`.
+export const createShieldedTokenPrivateState = (
+  nonceSeed = hashBytes32("shielded-token:demo-seed"),
+): ShieldedTokenPrivateState => ({
+  nonceSeed,
+  nextNonceIndex: 0n,
+});
 
-The suite covers:
+export const witnesses = {
+  localNonceSeed: ({ privateState }: WitnessContext<ShieldedTokenPrivateState>) => [
+    {
+      nonceSeed: privateState.nonceSeed,
+      nextNonceIndex: privateState.nextNonceIndex + 1n,
+    },
+    privateState.nonceSeed,
+  ],
+};
 
-- Minting a shielded coin to the contract and preserving token color.
-- Deterministic nonce derivation with `evolveNonce`.
-- Local nonce seed use through `mintWithLocalNonce`.
-- Rejection when `sendShielded` receives a fresh coin without `mtIndex`.
-- Partial sends that produce change.
-- Exact sends that produce no change.
-- Overspending rejection.
-- Zero-value rejection.
-- Committed burns through `shieldedBurnAddress`.
-- Fresh burns through `sendImmediateShielded`.
-- Atomic `mint_and_send`.
-- Spending change after it is committed.
-- Color preservation across send, burn, and change outputs.
+export function hashBytes32(input: string): Uint8Array {
+  return createHash("sha256").update(input).digest();
+}
+```
 
-This is the key test for Merkle timing:
+The witness returns the nonce seed to Compact and advances local private state.
+In a production DApp, persist this private state. Do not reset it casually, or
+you may reuse nonce material.
+
+## Part 8: Build a local test model
+
+Create a deterministic model for tests:
+
+```bash
+mkdir -p src/model
+touch src/model/shielded-token-model.ts
+```
+
+The model should mirror the standard library types closely:
+
+```ts
+export type ShieldedCoinInfo = {
+  readonly nonce: string;
+  readonly color: string;
+  readonly value: bigint;
+  readonly recipient: Recipient;
+};
+
+export type QualifiedShieldedCoinInfo = ShieldedCoinInfo & {
+  readonly mtIndex: bigint;
+};
+
+export type ShieldedSendResult = {
+  readonly sent: ShieldedCoinInfo;
+  readonly change: ShieldedCoinInfo | null;
+};
+```
+
+Then model the two send paths:
+
+```ts
+export function sendShielded(
+  input: QualifiedShieldedCoinInfo,
+  recipient: Recipient,
+  value: bigint | number,
+): ShieldedSendResult {
+  assertQualified(input);
+  return splitCoin(input, recipient, value, "sendShielded");
+}
+
+export function sendImmediateShielded(
+  input: ShieldedCoinInfo,
+  target: Recipient,
+  value: bigint | number,
+): ShieldedSendResult {
+  return splitCoin(input, target, value, "sendImmediateShielded");
+}
+```
+
+The important test helper is `assertQualified`. It rejects fresh coins that do
+not have an `mtIndex`:
+
+```ts
+function assertQualified(
+  input: ShieldedCoinInfo | QualifiedShieldedCoinInfo,
+): asserts input is QualifiedShieldedCoinInfo {
+  if (!("mtIndex" in input)) {
+    throw new Error("sendShielded requires a committed coin with an mtIndex");
+  }
+}
+```
+
+This is how the test suite makes the Merkle timing rule visible without running
+a full network.
+
+## Part 9: Write the Vitest suite
+
+Create the test file:
+
+```bash
+mkdir -p test
+touch test/shielded-token-lifecycle.test.ts
+```
+
+Start with a mint test:
+
+```ts
+it("mints a shielded coin to the contract with the expected color", () => {
+  const harness = new ShieldedTokenHarness(DOMAIN);
+
+  const coin = harness.mintToContract(1000n, NONCE);
+
+  expect(coin.value).toBe(1000n);
+  expect(coin.color).toEqual(tokenType(DOMAIN));
+  expect(coin.recipient).toEqual(CONTRACT_SELF);
+});
+```
+
+Add a nonce test:
+
+```ts
+it("derives deterministic unique nonces with evolveNonce", () => {
+  const first = evolveNonce(0n, SEED);
+  const second = evolveNonce(1n, SEED);
+
+  expect(first).not.toEqual(second);
+  expect(evolveNonce(0n, SEED)).toEqual(first);
+});
+```
+
+Add the Merkle timing test:
 
 ```ts
 it("requires a committed Merkle position before sendShielded can spend a coin", () => {
@@ -435,138 +585,199 @@ it("requires a committed Merkle position before sendShielded can spend a coin", 
 });
 ```
 
-The positive committed flow is equally important:
+Add committed transfer tests for partial and exact sends:
 
 ```ts
-const fresh = harness.mintToContract(100n, NONCE);
-const qualified = harness.commit(fresh);
+const qualified = harness.commit(harness.mintToContract(100n, NONCE));
 const result = harness.sendCommitted(qualified, ALICE, 35n);
 
 expect(result.sent.value).toBe(35n);
 expect(result.change?.value).toBe(65n);
 ```
 
-That mirrors the real operational sequence: create the output, wait for it to be
-available in the tree, then spend the qualified coin.
+Add burn tests for both paths:
 
-## Operational guidance
+```ts
+const committed = harness.commit(harness.mintToContract(90n, NONCE));
+const committedBurn = harness.burnCommitted(committed, 40n);
+expect(committedBurn.sent.recipient).toEqual(BURN_ADDRESS);
+expect(committedBurn.change?.value).toBe(50n);
 
-Production code should treat nonce state and change state as wallet-critical
-data. Losing track of a nonce can cause reuse risk. Losing track of change can
-make funds operationally inaccessible even if the chain accounting is correct.
-The tutorial contract returns the `ShieldedSendResult` from every send and burn
-path so callers cannot ignore change accidentally.
+const freshBurn = harness.burnFresh(75n, NONCE, 75n);
+expect(freshBurn.sent.recipient).toEqual(BURN_ADDRESS);
+expect(freshBurn.change).toBeNull();
+```
 
-The UI or service layer should store:
+Finally, test atomic mint-and-send:
 
-- The domain separator used for this token.
-- The local nonce seed and next index.
-- Newly minted `ShieldedCoinInfo` values until they are committed.
-- The `mtIndex` when a coin becomes spendable as `QualifiedShieldedCoinInfo`.
-- Returned change outputs and their later Merkle positions.
+```ts
+const result = harness.mintAndSend(120n, NONCE, ALICE, 45n);
 
-Do not hardcode a fake Merkle index for production spends. The only reason the
-test harness can create an index instantly is because it is a deterministic
-local model. A real application must get the actual committed index from the
-chain or wallet state.
+expect(result.sent.value).toBe(45n);
+expect(result.sent.recipient).toEqual(ALICE);
+expect(result.change?.value).toBe(75n);
+```
 
-## Common implementation mistakes
+The completed suite should cover normal flows and edge cases: over-spend,
+over-burn, zero-value operations, change reuse, fresh immediate sends, and color
+preservation.
 
-There are several mistakes that look harmless in a small demo but become serious
-when a contract is integrated into a wallet or service.
+Add one more test for change reuse. This test proves that change from a partial
+send is not just bookkeeping text; it is the next coin your application must
+commit and track:
 
-The first mistake is naming an exported circuit exactly like a standard library
-function. For example, an application circuit named `sendShielded` is easy for a
-reader to confuse with the library function `sendShielded`. This tutorial uses
-names such as `send_committed`, `burn_committed`, and `mint_and_send` so that the
-boundary between application code and standard library code stays clear.
+```ts
+it("allows change from one transaction to be committed and spent later", () => {
+  const harness = new ShieldedTokenHarness(DOMAIN);
+  const qualified = harness.commit(harness.mintToContract(100n, NONCE));
+  const first = harness.sendCommitted(qualified, ALICE, 30n);
 
-The second mistake is wrapping modern Compact code in an extra contract object
-when the surrounding examples use top-level ledger declarations, witnesses,
-constructors, and exported circuits. The current examples in the Midnight docs
-show top-level Compact modules. Matching that structure makes the generated
-TypeScript contract easier to use with the runtime patterns shown in example
-projects.
+  const change = harness.commit(first.change!);
+  const second = harness.sendCommitted(change, BOB, 20n);
 
-The third mistake is treating `ShieldedSendResult.change` as optional bookkeeping
-that can be handled later. It is optional in the type because exact sends do not
-create change. When it is present, however, it is a real output. The app should
-persist it, wait for it to be committed, and later qualify it with the real
-Merkle position. In the test suite, change from a first transfer is committed
-and spent in a second transfer to prove that the output remains usable.
+  expect(second.sent.value).toBe(20n);
+  expect(second.change?.value).toBe(50n);
+});
+```
 
-The fourth mistake is assuming a recipient public key behaves exactly like a
-contract recipient from a wallet-notification perspective. The standard library
-documentation notes that shielded sends do not currently create all user-facing
-coin ciphertext flows for arbitrary public key recipients. For a tutorial, it is
-still useful to demonstrate the correct recipient type:
-`left<ZswapCoinPublicKey, ContractAddress>(recipient)`. For production UX, the
-app must verify how the intended wallet discovers and tracks the resulting
-shielded output.
+This is the test that catches a common wallet integration bug. If the application
+forgets to store `first.change`, the user may believe the remaining value is
+still available, but the app will not know which output to qualify and spend
+later.
 
-The fifth mistake is confusing an immediate spend with a committed spend.
-`sendImmediateShielded` is not a shortcut to skip Merkle checks forever. It is
-for coins created in the current transaction. Once a transaction boundary is
-crossed, the app needs a qualified coin with `mtIndex` and should call
-`sendShielded`.
+## Part 10: Run the checks
 
-## Review and verification runbook
-
-A reviewer can check the package in three passes.
-
-First, inspect the Compact contract. Confirm that `mint_to_contract` calls
-`mintShieldedToken` with a contract recipient, that `send_committed` accepts a
-`QualifiedShieldedCoinInfo`, that committed burns send to `shieldedBurnAddress`,
-and that the fresh paths use `sendImmediateShielded`. Also confirm that the
-contract validates non-zero amounts and rejects sends or burns larger than the
-input value.
-
-Second, run the TypeScript checks:
+Run TypeScript:
 
 ```bash
-npm install
 npm run typecheck
+```
+
+Expected output:
+
+```text
+tsc -p tsconfig.json --noEmit
+```
+
+Run the tests:
+
+```bash
 npm test
 ```
 
-The unit tests are deterministic. They do not require a node, wallet, faucet, or
-proof server. That makes them suitable for CI and for quickly validating the
-control-flow assumptions in the tutorial. The tests are not a replacement for a
-real Compact compile or an integration test against a deployed contract, but
-they are a useful guardrail for the logic around change, burn destinations, and
-fresh versus committed coins.
+Expected output:
 
-Third, run the Compact compiler:
+```text
+Test Files  1 passed (1)
+Tests  18 passed (18)
+```
+
+Compile the Compact smart contract:
 
 ```bash
 npm run compact
 ```
 
-The expected output is a generated directory under `src/managed`. A complete
-application would then import the generated `Contract` class, pass the
-`witnesses` object from `src/witnesses.ts`, and drive the circuits through the
-Compact runtime in the same style as the official example applications. That
-integration layer is intentionally small because the bounty is about the
-shielded token operations themselves, not about building a full wallet UI.
+Expected result:
 
-If the compiler reports a field-name error around `QualifiedShieldedCoinInfo`,
-check the installed Compact toolchain version against the documentation. The
-reference page documents the Merkle field as `mtIndex`. Some older examples have
-used different casing. This package avoids manually constructing a qualified
-coin in Compact for the atomic flow and instead uses `sendImmediateShielded`,
-which is the safer API for a freshly minted coin.
+```text
+Compilation successful
+```
 
-## Summary
+The compile step creates generated contract files under `src/managed`. Those
+generated files are build output and do not need to be committed.
 
-The lifecycle is straightforward once the two coin states are kept separate.
-`mintShieldedToken` creates a fresh `ShieldedCoinInfo`. `sendImmediateShielded`
-spends fresh coins within the same transaction. `sendShielded` spends committed
-coins that already have a Merkle position. `shieldedBurnAddress()` turns a send
-into a burn. `ShieldedSendResult.change` is where unspent value continues after
-a partial send or partial burn. Finally, `evolveNonce` should be part of a
-deliberate nonce policy, not an afterthought.
+For final review, record the three verification results together:
 
-Together, the Compact contract and Vitest suite provide a small but complete
-reference implementation for mint, transfer, burn, change handling, nonce
-management, and the Merkle timing constraint that makes shielded token code easy
-to get wrong.
+```text
+Compact compiler: passed
+TypeScript: passed
+Vitest: 18 tests passed
+```
+
+Do not treat the Vitest result as a substitute for Compact compilation. The
+tests prove the lifecycle model and edge cases. The compiler proves the Compact
+syntax, types, witness disclosure, and standard library calls.
+
+## Troubleshooting
+
+### `compact` runs the wrong command on Windows
+
+Problem:
+
+```text
+Listing ... New files added to this directory will not be compressed.
+```
+
+That is the Windows filesystem compression utility, not the Midnight compiler.
+
+Fix:
+
+- Run the command from WSL, or
+- Put the Midnight Compact toolchain earlier in `PATH` than
+  `C:\Windows\System32`.
+
+### The compiler complains about witness disclosure
+
+Problem:
+
+```text
+potential witness-value disclosure must be declared but is not
+```
+
+Fix:
+
+Wrap the evolved nonce in `disclose(...)`:
+
+```compact
+const nonce = disclose(evolveNonce(disclose(nonceIndex), localNonceSeed()));
+```
+
+This declares the intentional disclosure of the derived nonce value, not the raw
+witness seed.
+
+### A later transfer fails because the coin has no `mtIndex`
+
+Problem:
+
+You are trying to call `sendShielded` with a fresh `ShieldedCoinInfo`.
+
+Fix:
+
+Use `sendImmediateShielded` if the coin was created in the same transaction. If
+the coin was created in a previous transaction, wait until it is committed and
+spend it as a `QualifiedShieldedCoinInfo` with the real Merkle index.
+
+### Change disappears from your app state
+
+Problem:
+
+A partial send or burn returns change, but the app does not store it.
+
+Fix:
+
+Always inspect `ShieldedSendResult.change`. If it is present, persist it and
+track its later Merkle position. That change is the remaining balance.
+
+## Conclusion
+
+You have built a complete shielded token lifecycle example:
+
+- `mintShieldedToken` creates fresh shielded coins.
+- `evolveNonce` gives you deterministic nonce derivation.
+- `sendShielded` spends committed coins with `mtIndex`.
+- `sendImmediateShielded` spends coins created in the same transaction.
+- `shieldedBurnAddress` turns a shielded send into a burn.
+- `ShieldedSendResult.change` carries the unspent remainder.
+- Vitest tests prove the normal paths and the common failure cases.
+
+The most important lesson is the fresh-versus-committed distinction. If you keep
+that boundary clear, shielded mint, transfer, and burn operations become much
+easier to reason about.
+
+Related resources:
+
+- Midnight documentation: https://docs.midnight.network/
+- Compact language reference: https://docs.midnight.network/compact/
+- Compact standard library exports:
+  https://docs.midnight.network/compact/standard-library/exports

--- a/bounties/327-shielded-token-operations/TUTORIAL.md
+++ b/bounties/327-shielded-token-operations/TUTORIAL.md
@@ -1,0 +1,572 @@
+<!--
+This file is part of midnightntwrk/contributor-hub.
+Copyright (C) 2025 Midnight Foundation
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Shielded Token Operations: Mint, Transfer, Burn, and Tests
+
+This tutorial walks through a small Compact contract that demonstrates a full
+shielded token lifecycle on Midnight: minting a shielded coin, spending it to a
+recipient, returning change, burning shielded value, and testing the edge cases
+that matter for production code. The companion code lives in this directory and
+is organized as a minimal package that can be installed, typechecked, tested
+with Vitest, and compiled with the Midnight Compact toolchain.
+
+The examples focus on contract-owned shielded coins. A contract mints a shielded
+token to itself, later spends the committed coin with `sendShielded`, and uses
+`ShieldedSendResult.change` to keep track of any remaining value. The same
+contract also demonstrates the immediate path: when a coin is created and spent
+inside the same transaction, it is a `ShieldedCoinInfo`, not a
+`QualifiedShieldedCoinInfo`, so the correct helper is `sendImmediateShielded`.
+This distinction is the main trap in this topic.
+
+## Project shape
+
+The package contains four important files:
+
+- `src/shielded-token-lifecycle.compact` contains the Compact circuits.
+- `src/witnesses.ts` implements local private state for nonce seed management.
+- `src/model/shielded-token-model.ts` mirrors the shielded-token rules for
+  deterministic unit tests.
+- `test/shielded-token-lifecycle.test.ts` covers mint, transfer, burn, change,
+  nonce evolution, and Merkle timing.
+
+Install the package and run the tests:
+
+```bash
+npm install
+npm run typecheck
+npm test
+```
+
+Compile the Compact contract after installing the Midnight Compact toolchain:
+
+```bash
+npm run compact
+```
+
+On Windows, be careful with the command name. Windows ships a system utility
+named `compact.exe` for filesystem compression. If that binary appears before
+the Midnight toolchain in `PATH`, `npm run compact` will call the wrong program.
+Using WSL or adjusting `PATH` avoids that collision.
+
+## Compact contract structure
+
+The contract starts like current Midnight examples: no wrapper object, a language
+version pragma, and an import of the standard library.
+
+```compact
+pragma language_version >= 0.20;
+
+import CompactStandardLibrary;
+
+export ledger mintedOperations: Counter;
+export ledger totalBurned: Uint<128>;
+
+constructor() {
+  totalBurned = 0;
+}
+```
+
+`mintedOperations` is a simple counter so tests and users can see that a minting
+path was executed. `totalBurned` records the amount that the contract has sent
+to the shielded burn address. This is not meant to replace chain accounting, but
+it is useful application state for a tutorial because it makes the burn path
+observable.
+
+The contract also declares one witness:
+
+```compact
+witness localNonceSeed(): Bytes<32>;
+```
+
+The witness returns a private local seed. The Compact circuit can combine that
+seed with a public index by calling `evolveNonce(index, nonce)`. This pattern
+keeps nonce generation deterministic while making accidental nonce reuse easier
+to avoid. A production app should persist its private state and should never
+reset the seed/index pair in a way that reuses the same nonce for the same token
+domain.
+
+## Minting shielded tokens
+
+The standard library function used for minting is:
+
+```compact
+mintShieldedToken(
+  domainSep: Bytes<32>,
+  value: Uint<64>,
+  nonce: Bytes<32>,
+  recipient: Either<ZswapCoinPublicKey, ContractAddress>
+): ShieldedCoinInfo
+```
+
+The returned `ShieldedCoinInfo` describes a newly created shielded output. It
+has a `nonce`, `color`, and `value`. The `color` is the token type derived from
+the domain separator and contract address. The `nonce` must be unique for secure
+operation.
+
+The tutorial contract exposes an explicit mint function:
+
+```compact
+export circuit mint_to_contract(
+  domainSep: Bytes<32>,
+  value: Uint<64>,
+  nonce: Bytes<32>
+): ShieldedCoinInfo {
+  assert(disclose(value) > 0, "mint amount must be non-zero");
+
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(value),
+    disclose(nonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  mintedOperations.increment(1);
+  return coin;
+}
+```
+
+The recipient is `right<ZswapCoinPublicKey, ContractAddress>(kernel.self())`,
+which means the shielded output is addressed to the current contract. This is
+the important choice for the rest of the tutorial: the contract can later spend
+that coin after it is committed on-chain and referenced as a
+`QualifiedShieldedCoinInfo`.
+
+There is also a nonce-managed mint:
+
+```compact
+export circuit mint_with_local_nonce(
+  domainSep: Bytes<32>,
+  value: Uint<64>,
+  nonceIndex: Uint<128>
+): ShieldedCoinInfo {
+  assert(disclose(value) > 0, "mint amount must be non-zero");
+
+  const nonce = disclose(evolveNonce(disclose(nonceIndex), localNonceSeed()));
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(value),
+    nonce,
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  mintedOperations.increment(1);
+  return coin;
+}
+```
+
+The point is not that every application must use exactly this API. The point is
+that the nonce policy should be explicit. Passing arbitrary nonces from a UI is
+easy to demo and easy to get wrong. Passing an index and deriving the nonce from
+a private seed gives the application a clear place to enforce monotonic use. The
+`disclose(...)` wrapper around the evolved nonce is intentional. Compact tracks
+values derived from witnesses, and a minted coin returns a nonce-derived output.
+By disclosing the evolved nonce, the contract declares that this obfuscated
+derived value may be visible without disclosing the raw witness seed itself.
+
+## TypeScript witness implementation
+
+The witness implementation in `src/witnesses.ts` defines the private state shape:
+
+```ts
+export type ShieldedTokenPrivateState = {
+  readonly nonceSeed: Uint8Array;
+  readonly nextNonceIndex: bigint;
+};
+```
+
+It also exports a constructor for the state and a `witnesses` object with a
+`localNonceSeed` implementation:
+
+```ts
+export const witnesses = {
+  localNonceSeed: ({ privateState }) => [
+    {
+      nonceSeed: privateState.nonceSeed,
+      nextNonceIndex: privateState.nextNonceIndex + 1n,
+    },
+    privateState.nonceSeed,
+  ],
+};
+```
+
+The returned tuple follows the generated Compact runtime pattern: first the next
+private state, then the witness value returned to the circuit. The circuit still
+takes a `nonceIndex` parameter. Keeping the index visible in the circuit makes
+tests and callers explicit about which nonce should be used for a mint, while the
+private state gives the UI or service layer a way to track local progress.
+
+## Sending committed shielded coins
+
+The standard library distinguishes fresh shielded coins from committed shielded
+coins. `ShieldedCoinInfo` is a new coin, usually created in the current
+transaction. `QualifiedShieldedCoinInfo` is a coin that already exists in the
+ledger and includes a Merkle tree position:
+
+```compact
+struct QualifiedShieldedCoinInfo {
+  nonce: Bytes<32>;
+  color: Bytes<32>;
+  value: Uint<128>;
+  mtIndex: Uint<64>;
+}
+```
+
+That `mtIndex` is load-bearing. The Merkle index is what lets the transaction
+prove which committed coin is being spent. A fresh output from
+`mintShieldedToken` does not have this index yet.
+
+The committed send circuit therefore accepts a `QualifiedShieldedCoinInfo`:
+
+```compact
+export circuit send_committed(
+  input: QualifiedShieldedCoinInfo,
+  recipient: ZswapCoinPublicKey,
+  value: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(value) > 0, "send amount must be non-zero");
+  assert(disclose(input).value >= disclose(value), "send amount exceeds coin value");
+
+  return sendShielded(
+    disclose(input),
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(value)
+  );
+}
+```
+
+The result is a `ShieldedSendResult`:
+
+```compact
+struct ShieldedSendResult {
+  change: Maybe<ShieldedCoinInfo>;
+  sent: ShieldedCoinInfo;
+}
+```
+
+When the input value is larger than the send value, `change` contains a new
+contract-owned `ShieldedCoinInfo`. The application must not forget this value.
+The change output is how the remaining balance continues to exist. If the input
+is exactly consumed, `change` is empty.
+
+Tests should verify both cases. The suite includes one test that sends `35` out
+of a `100` value coin and expects `65` of change, and another that sends exactly
+`100` and expects no change.
+
+## Burning shielded value
+
+The standard library exposes a special burn recipient:
+
+```compact
+shieldedBurnAddress(): Either<ZswapCoinPublicKey, ContractAddress>
+```
+
+Any shielded coins sent to that address are burned. The committed burn circuit
+is a small variant of the committed send path:
+
+```compact
+export circuit burn_committed(
+  input: QualifiedShieldedCoinInfo,
+  value: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(value) > 0, "burn amount must be non-zero");
+  assert(disclose(input).value >= disclose(value), "burn amount exceeds coin value");
+
+  const result = sendShielded(
+    disclose(input),
+    shieldedBurnAddress(),
+    disclose(value)
+  );
+
+  totalBurned = (totalBurned + disclose(value)) as Uint<128>;
+  return result;
+}
+```
+
+The burn result can also include change. Burning `40` out of a `90` value coin
+creates a burned output of `40` and a contract-owned change output of `50`. That
+change output must be committed before it can be spent by a later `sendShielded`
+call.
+
+Fresh burns use a different helper:
+
+```compact
+export circuit burn_fresh(
+  domainSep: Bytes<32>,
+  mintValue: Uint<64>,
+  mintNonce: Bytes<32>,
+  burnValue: Uint<128>
+): ShieldedSendResult {
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(mintValue),
+    disclose(mintNonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  assert(coin.value >= disclose(burnValue), "burn amount exceeds minted value");
+
+  const result = sendImmediateShielded(
+    coin,
+    shieldedBurnAddress(),
+    disclose(burnValue)
+  );
+
+  mintedOperations.increment(1);
+  totalBurned = (totalBurned + disclose(burnValue)) as Uint<128>;
+  return result;
+}
+```
+
+`sendImmediateShielded` is specifically for coins created in the current
+transaction. No Merkle index is required because the coin has not needed to be
+looked up as a previously committed input.
+
+## Atomic mint and send
+
+The same immediate rule applies to atomic mint-and-send. If the contract mints a
+coin and sends part of it to a user in the same circuit, it should not pretend
+the fresh coin has an existing Merkle position. It can directly call
+`sendImmediateShielded`:
+
+```compact
+export circuit mint_and_send(
+  domainSep: Bytes<32>,
+  mintValue: Uint<64>,
+  mintNonce: Bytes<32>,
+  recipient: ZswapCoinPublicKey,
+  sendValue: Uint<128>
+): ShieldedSendResult {
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(mintValue),
+    disclose(mintNonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  assert(coin.value >= disclose(sendValue), "send amount exceeds minted value");
+
+  const result = sendImmediateShielded(
+    coin,
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(sendValue)
+  );
+
+  mintedOperations.increment(1);
+  return result;
+}
+```
+
+This circuit is useful for onboarding flows, reward distribution, or any case
+where a contract creates shielded value and immediately passes some of it to a
+recipient. If `mintValue` is larger than `sendValue`, the returned change should
+be kept by the contract and committed before a future committed spend.
+
+## Merkle timing pitfall
+
+The most common mistake is trying to spend a freshly minted `ShieldedCoinInfo`
+with `sendShielded` in a later operation without first obtaining its
+`mtIndex`. A coin created in transaction A is only spendable by `sendShielded`
+after transaction A is included and the output can be referenced from the Merkle
+tree. Before that point, it is just a fresh output.
+
+There are three safe paths:
+
+1. Mint now, wait until the coin is committed, then spend it as a
+   `QualifiedShieldedCoinInfo` with `sendShielded`.
+2. Mint and spend inside the same transaction with `sendImmediateShielded`.
+3. Mint and burn inside the same transaction with `sendImmediateShielded` and
+   `shieldedBurnAddress()`.
+
+The test model enforces this distinction. If a test passes a fresh
+`ShieldedCoinInfo` into `sendShielded`, it throws an error that mentions
+`mtIndex`. The positive committed path calls `commit(coin)` first, which returns
+a `QualifiedShieldedCoinInfo`.
+
+## Test suite design
+
+The Vitest suite uses a deterministic TypeScript model rather than talking to a
+live network. This makes the tests fast and focused on lifecycle semantics. The
+model is intentionally shaped like the Compact standard library types:
+
+- `ShieldedCoinInfo` has `nonce`, `color`, `value`, and a test-only recipient.
+- `QualifiedShieldedCoinInfo` extends it with `mtIndex`.
+- `ShieldedSendResult` has `sent` and nullable `change`.
+
+The suite covers:
+
+- Minting a shielded coin to the contract and preserving token color.
+- Deterministic nonce derivation with `evolveNonce`.
+- Local nonce seed use through `mintWithLocalNonce`.
+- Rejection when `sendShielded` receives a fresh coin without `mtIndex`.
+- Partial sends that produce change.
+- Exact sends that produce no change.
+- Overspending rejection.
+- Zero-value rejection.
+- Committed burns through `shieldedBurnAddress`.
+- Fresh burns through `sendImmediateShielded`.
+- Atomic `mint_and_send`.
+- Spending change after it is committed.
+- Color preservation across send, burn, and change outputs.
+
+This is the key test for Merkle timing:
+
+```ts
+it("requires a committed Merkle position before sendShielded can spend a coin", () => {
+  const harness = new ShieldedTokenHarness(DOMAIN);
+  const fresh = harness.mintToContract(25n, NONCE);
+
+  expect(() =>
+    sendShielded(fresh as unknown as QualifiedShieldedCoinInfo, ALICE, 5n),
+  ).toThrow(/mtIndex/);
+});
+```
+
+The positive committed flow is equally important:
+
+```ts
+const fresh = harness.mintToContract(100n, NONCE);
+const qualified = harness.commit(fresh);
+const result = harness.sendCommitted(qualified, ALICE, 35n);
+
+expect(result.sent.value).toBe(35n);
+expect(result.change?.value).toBe(65n);
+```
+
+That mirrors the real operational sequence: create the output, wait for it to be
+available in the tree, then spend the qualified coin.
+
+## Operational guidance
+
+Production code should treat nonce state and change state as wallet-critical
+data. Losing track of a nonce can cause reuse risk. Losing track of change can
+make funds operationally inaccessible even if the chain accounting is correct.
+The tutorial contract returns the `ShieldedSendResult` from every send and burn
+path so callers cannot ignore change accidentally.
+
+The UI or service layer should store:
+
+- The domain separator used for this token.
+- The local nonce seed and next index.
+- Newly minted `ShieldedCoinInfo` values until they are committed.
+- The `mtIndex` when a coin becomes spendable as `QualifiedShieldedCoinInfo`.
+- Returned change outputs and their later Merkle positions.
+
+Do not hardcode a fake Merkle index for production spends. The only reason the
+test harness can create an index instantly is because it is a deterministic
+local model. A real application must get the actual committed index from the
+chain or wallet state.
+
+## Common implementation mistakes
+
+There are several mistakes that look harmless in a small demo but become serious
+when a contract is integrated into a wallet or service.
+
+The first mistake is naming an exported circuit exactly like a standard library
+function. For example, an application circuit named `sendShielded` is easy for a
+reader to confuse with the library function `sendShielded`. This tutorial uses
+names such as `send_committed`, `burn_committed`, and `mint_and_send` so that the
+boundary between application code and standard library code stays clear.
+
+The second mistake is wrapping modern Compact code in an extra contract object
+when the surrounding examples use top-level ledger declarations, witnesses,
+constructors, and exported circuits. The current examples in the Midnight docs
+show top-level Compact modules. Matching that structure makes the generated
+TypeScript contract easier to use with the runtime patterns shown in example
+projects.
+
+The third mistake is treating `ShieldedSendResult.change` as optional bookkeeping
+that can be handled later. It is optional in the type because exact sends do not
+create change. When it is present, however, it is a real output. The app should
+persist it, wait for it to be committed, and later qualify it with the real
+Merkle position. In the test suite, change from a first transfer is committed
+and spent in a second transfer to prove that the output remains usable.
+
+The fourth mistake is assuming a recipient public key behaves exactly like a
+contract recipient from a wallet-notification perspective. The standard library
+documentation notes that shielded sends do not currently create all user-facing
+coin ciphertext flows for arbitrary public key recipients. For a tutorial, it is
+still useful to demonstrate the correct recipient type:
+`left<ZswapCoinPublicKey, ContractAddress>(recipient)`. For production UX, the
+app must verify how the intended wallet discovers and tracks the resulting
+shielded output.
+
+The fifth mistake is confusing an immediate spend with a committed spend.
+`sendImmediateShielded` is not a shortcut to skip Merkle checks forever. It is
+for coins created in the current transaction. Once a transaction boundary is
+crossed, the app needs a qualified coin with `mtIndex` and should call
+`sendShielded`.
+
+## Review and verification runbook
+
+A reviewer can check the package in three passes.
+
+First, inspect the Compact contract. Confirm that `mint_to_contract` calls
+`mintShieldedToken` with a contract recipient, that `send_committed` accepts a
+`QualifiedShieldedCoinInfo`, that committed burns send to `shieldedBurnAddress`,
+and that the fresh paths use `sendImmediateShielded`. Also confirm that the
+contract validates non-zero amounts and rejects sends or burns larger than the
+input value.
+
+Second, run the TypeScript checks:
+
+```bash
+npm install
+npm run typecheck
+npm test
+```
+
+The unit tests are deterministic. They do not require a node, wallet, faucet, or
+proof server. That makes them suitable for CI and for quickly validating the
+control-flow assumptions in the tutorial. The tests are not a replacement for a
+real Compact compile or an integration test against a deployed contract, but
+they are a useful guardrail for the logic around change, burn destinations, and
+fresh versus committed coins.
+
+Third, run the Compact compiler:
+
+```bash
+npm run compact
+```
+
+The expected output is a generated directory under `src/managed`. A complete
+application would then import the generated `Contract` class, pass the
+`witnesses` object from `src/witnesses.ts`, and drive the circuits through the
+Compact runtime in the same style as the official example applications. That
+integration layer is intentionally small because the bounty is about the
+shielded token operations themselves, not about building a full wallet UI.
+
+If the compiler reports a field-name error around `QualifiedShieldedCoinInfo`,
+check the installed Compact toolchain version against the documentation. The
+reference page documents the Merkle field as `mtIndex`. Some older examples have
+used different casing. This package avoids manually constructing a qualified
+coin in Compact for the atomic flow and instead uses `sendImmediateShielded`,
+which is the safer API for a freshly minted coin.
+
+## Summary
+
+The lifecycle is straightforward once the two coin states are kept separate.
+`mintShieldedToken` creates a fresh `ShieldedCoinInfo`. `sendImmediateShielded`
+spends fresh coins within the same transaction. `sendShielded` spends committed
+coins that already have a Merkle position. `shieldedBurnAddress()` turns a send
+into a burn. `ShieldedSendResult.change` is where unspent value continues after
+a partial send or partial burn. Finally, `evolveNonce` should be part of a
+deliberate nonce policy, not an afterthought.
+
+Together, the Compact contract and Vitest suite provide a small but complete
+reference implementation for mint, transfer, burn, change handling, nonce
+management, and the Merkle timing constraint that makes shielded token code easy
+to get wrong.

--- a/bounties/327-shielded-token-operations/package-lock.json
+++ b/bounties/327-shielded-token-operations/package-lock.json
@@ -1,0 +1,1299 @@
+{
+  "name": "midnight-bounty-327-shielded-token-operations",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "midnight-bounty-327-shielded-token-operations",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^24.10.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/bounties/327-shielded-token-operations/package.json
+++ b/bounties/327-shielded-token-operations/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "midnight-bounty-327-shielded-token-operations",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "compact": "compact compile src/shielded-token-lifecycle.compact ./src/managed/shielded-token-lifecycle",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/bounties/327-shielded-token-operations/src/model/shielded-token-model.ts
+++ b/bounties/327-shielded-token-operations/src/model/shielded-token-model.ts
@@ -1,0 +1,237 @@
+// This file is part of midnightntwrk/contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createHash } from "node:crypto";
+
+export type Recipient =
+  | { readonly kind: "contract"; readonly value: string }
+  | { readonly kind: "publicKey"; readonly value: string }
+  | { readonly kind: "burn"; readonly value: string };
+
+export type ShieldedCoinInfo = {
+  readonly nonce: string;
+  readonly color: string;
+  readonly value: bigint;
+  readonly recipient: Recipient;
+};
+
+export type QualifiedShieldedCoinInfo = ShieldedCoinInfo & {
+  readonly mtIndex: bigint;
+};
+
+export type ShieldedSendResult = {
+  readonly sent: ShieldedCoinInfo;
+  readonly change: ShieldedCoinInfo | null;
+};
+
+export const CONTRACT_SELF: Recipient = {
+  kind: "contract",
+  value: hashBytes32("kernel.self"),
+};
+
+export const BURN_ADDRESS: Recipient = {
+  kind: "burn",
+  value: hashBytes32("shieldedBurnAddress"),
+};
+
+export function hashBytes32(...parts: readonly string[]): string {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(part);
+    hash.update("\0");
+  }
+  return `0x${hash.digest("hex")}`;
+}
+
+export function publicKey(label: string): Recipient {
+  return {
+    kind: "publicKey",
+    value: hashBytes32("publicKey", label),
+  };
+}
+
+export function evolveNonce(index: bigint | number, nonce: string): string {
+  return hashBytes32("evolveNonce", BigInt(index).toString(), normalizeBytes32(nonce));
+}
+
+export function tokenType(domainSep: string, contract = CONTRACT_SELF.value): string {
+  return hashBytes32("tokenType", normalizeBytes32(domainSep), contract);
+}
+
+export function mintShieldedToken(
+  domainSep: string,
+  value: bigint | number,
+  nonce: string,
+  recipient: Recipient = CONTRACT_SELF,
+): ShieldedCoinInfo {
+  const amount = normalizeAmount(value);
+  return {
+    nonce: normalizeBytes32(nonce),
+    color: tokenType(domainSep),
+    value: amount,
+    recipient,
+  };
+}
+
+export function commitCoin(
+  coin: ShieldedCoinInfo,
+  mtIndex: bigint | number,
+): QualifiedShieldedCoinInfo {
+  return {
+    ...coin,
+    mtIndex: BigInt(mtIndex),
+  };
+}
+
+export function sendShielded(
+  input: QualifiedShieldedCoinInfo,
+  recipient: Recipient,
+  value: bigint | number,
+): ShieldedSendResult {
+  assertQualified(input);
+  return splitCoin(input, recipient, value, "sendShielded");
+}
+
+export function sendImmediateShielded(
+  input: ShieldedCoinInfo,
+  target: Recipient,
+  value: bigint | number,
+): ShieldedSendResult {
+  return splitCoin(input, target, value, "sendImmediateShielded");
+}
+
+export function shieldedBurnAddress(): Recipient {
+  return BURN_ADDRESS;
+}
+
+export class ShieldedTokenHarness {
+  private nextMtIndex = 0n;
+  readonly domainSep: string;
+  totalBurned = 0n;
+  mintedOperations = 0;
+
+  constructor(domainSep = hashBytes32("shielded-token:domain")) {
+    this.domainSep = domainSep;
+  }
+
+  mintToContract(value: bigint | number, nonce: string): ShieldedCoinInfo {
+    const coin = mintShieldedToken(this.domainSep, value, nonce, CONTRACT_SELF);
+    this.mintedOperations += 1;
+    return coin;
+  }
+
+  mintWithLocalNonce(value: bigint | number, seed: string, index: bigint | number): ShieldedCoinInfo {
+    return this.mintToContract(value, evolveNonce(index, seed));
+  }
+
+  commit(coin: ShieldedCoinInfo): QualifiedShieldedCoinInfo {
+    const qualified = commitCoin(coin, this.nextMtIndex);
+    this.nextMtIndex += 1n;
+    return qualified;
+  }
+
+  sendCommitted(
+    input: QualifiedShieldedCoinInfo,
+    recipient: Recipient,
+    value: bigint | number,
+  ): ShieldedSendResult {
+    return sendShielded(input, recipient, value);
+  }
+
+  burnCommitted(
+    input: QualifiedShieldedCoinInfo,
+    value: bigint | number,
+  ): ShieldedSendResult {
+    const result = sendShielded(input, shieldedBurnAddress(), value);
+    this.totalBurned += normalizeAmount(value);
+    return result;
+  }
+
+  burnFresh(
+    mintValue: bigint | number,
+    mintNonce: string,
+    burnValue: bigint | number,
+  ): ShieldedSendResult {
+    const coin = this.mintToContract(mintValue, mintNonce);
+    const result = sendImmediateShielded(coin, shieldedBurnAddress(), burnValue);
+    this.totalBurned += normalizeAmount(burnValue);
+    return result;
+  }
+
+  mintAndSend(
+    mintValue: bigint | number,
+    mintNonce: string,
+    recipient: Recipient,
+    sendValue: bigint | number,
+  ): ShieldedSendResult {
+    const coin = this.mintToContract(mintValue, mintNonce);
+    return sendImmediateShielded(coin, recipient, sendValue);
+  }
+}
+
+function splitCoin(
+  input: ShieldedCoinInfo,
+  recipient: Recipient,
+  value: bigint | number,
+  operation: string,
+): ShieldedSendResult {
+  const amount = normalizeAmount(value);
+  if (amount > input.value) {
+    throw new Error(`${operation} amount exceeds coin value`);
+  }
+
+  const sent: ShieldedCoinInfo = {
+    nonce: evolveNonce(1n, input.nonce),
+    color: input.color,
+    value: amount,
+    recipient,
+  };
+
+  const changeValue = input.value - amount;
+  const change =
+    changeValue === 0n
+      ? null
+      : {
+          nonce: evolveNonce(2n, input.nonce),
+          color: input.color,
+          value: changeValue,
+          recipient: CONTRACT_SELF,
+        };
+
+  return { sent, change };
+}
+
+function assertQualified(
+  input: ShieldedCoinInfo | QualifiedShieldedCoinInfo,
+): asserts input is QualifiedShieldedCoinInfo {
+  if (!("mtIndex" in input)) {
+    throw new Error("sendShielded requires a committed coin with an mtIndex");
+  }
+}
+
+function normalizeAmount(value: bigint | number): bigint {
+  const amount = BigInt(value);
+  if (amount <= 0n) {
+    throw new Error("amount must be non-zero");
+  }
+  return amount;
+}
+
+function normalizeBytes32(value: string): string {
+  if (/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    return value.toLowerCase();
+  }
+  return hashBytes32("bytes32", value);
+}

--- a/bounties/327-shielded-token-operations/src/shielded-token-lifecycle.compact
+++ b/bounties/327-shielded-token-operations/src/shielded-token-lifecycle.compact
@@ -1,0 +1,154 @@
+// This file is part of midnightntwrk/contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pragma language_version >= 0.20;
+
+import CompactStandardLibrary;
+
+export ledger mintedOperations: Counter;
+export ledger totalBurned: Uint<128>;
+
+constructor() {
+  totalBurned = 0;
+}
+
+witness localNonceSeed(): Bytes<32>;
+
+export circuit mint_to_contract(
+  domainSep: Bytes<32>,
+  value: Uint<64>,
+  nonce: Bytes<32>
+): ShieldedCoinInfo {
+  assert(disclose(value) > 0, "mint amount must be non-zero");
+
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(value),
+    disclose(nonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  mintedOperations.increment(1);
+  return coin;
+}
+
+export circuit mint_with_local_nonce(
+  domainSep: Bytes<32>,
+  value: Uint<64>,
+  nonceIndex: Uint<128>
+): ShieldedCoinInfo {
+  assert(disclose(value) > 0, "mint amount must be non-zero");
+
+  const nonce = disclose(evolveNonce(disclose(nonceIndex), localNonceSeed()));
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(value),
+    nonce,
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  mintedOperations.increment(1);
+  return coin;
+}
+
+export circuit send_committed(
+  input: QualifiedShieldedCoinInfo,
+  recipient: ZswapCoinPublicKey,
+  value: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(value) > 0, "send amount must be non-zero");
+  assert(disclose(input).value >= disclose(value), "send amount exceeds coin value");
+
+  return sendShielded(
+    disclose(input),
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(value)
+  );
+}
+
+export circuit burn_committed(
+  input: QualifiedShieldedCoinInfo,
+  value: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(value) > 0, "burn amount must be non-zero");
+  assert(disclose(input).value >= disclose(value), "burn amount exceeds coin value");
+
+  const result = sendShielded(
+    disclose(input),
+    shieldedBurnAddress(),
+    disclose(value)
+  );
+
+  totalBurned = (totalBurned + disclose(value)) as Uint<128>;
+  return result;
+}
+
+export circuit burn_fresh(
+  domainSep: Bytes<32>,
+  mintValue: Uint<64>,
+  mintNonce: Bytes<32>,
+  burnValue: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(mintValue) > 0, "mint amount must be non-zero");
+  assert(disclose(burnValue) > 0, "burn amount must be non-zero");
+
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(mintValue),
+    disclose(mintNonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  assert(coin.value >= disclose(burnValue), "burn amount exceeds minted value");
+
+  const result = sendImmediateShielded(
+    coin,
+    shieldedBurnAddress(),
+    disclose(burnValue)
+  );
+
+  mintedOperations.increment(1);
+  totalBurned = (totalBurned + disclose(burnValue)) as Uint<128>;
+  return result;
+}
+
+export circuit mint_and_send(
+  domainSep: Bytes<32>,
+  mintValue: Uint<64>,
+  mintNonce: Bytes<32>,
+  recipient: ZswapCoinPublicKey,
+  sendValue: Uint<128>
+): ShieldedSendResult {
+  assert(disclose(mintValue) > 0, "mint amount must be non-zero");
+  assert(disclose(sendValue) > 0, "send amount must be non-zero");
+
+  const coin = mintShieldedToken(
+    disclose(domainSep),
+    disclose(mintValue),
+    disclose(mintNonce),
+    right<ZswapCoinPublicKey, ContractAddress>(kernel.self())
+  );
+
+  assert(coin.value >= disclose(sendValue), "send amount exceeds minted value");
+
+  const result = sendImmediateShielded(
+    coin,
+    left<ZswapCoinPublicKey, ContractAddress>(disclose(recipient)),
+    disclose(sendValue)
+  );
+
+  mintedOperations.increment(1);
+  return result;
+}

--- a/bounties/327-shielded-token-operations/src/witnesses.ts
+++ b/bounties/327-shielded-token-operations/src/witnesses.ts
@@ -1,0 +1,51 @@
+// This file is part of midnightntwrk/contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createHash } from "node:crypto";
+
+export type ShieldedTokenPrivateState = {
+  readonly nonceSeed: Uint8Array;
+  readonly nextNonceIndex: bigint;
+};
+
+type WitnessContext<PrivateState> = {
+  readonly privateState: PrivateState;
+};
+
+export const createShieldedTokenPrivateState = (
+  nonceSeed = hashBytes32("shielded-token:demo-seed"),
+): ShieldedTokenPrivateState => ({
+  nonceSeed,
+  nextNonceIndex: 0n,
+});
+
+export const witnesses = {
+  localNonceSeed: ({
+    privateState,
+  }: WitnessContext<ShieldedTokenPrivateState>): [
+    ShieldedTokenPrivateState,
+    Uint8Array,
+  ] => [
+    {
+      nonceSeed: privateState.nonceSeed,
+      nextNonceIndex: privateState.nextNonceIndex + 1n,
+    },
+    privateState.nonceSeed,
+  ],
+};
+
+export function hashBytes32(input: string): Uint8Array {
+  return createHash("sha256").update(input).digest();
+}

--- a/bounties/327-shielded-token-operations/test/shielded-token-lifecycle.test.ts
+++ b/bounties/327-shielded-token-operations/test/shielded-token-lifecycle.test.ts
@@ -1,0 +1,241 @@
+// This file is part of midnightntwrk/contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, it } from "vitest";
+import {
+  BURN_ADDRESS,
+  CONTRACT_SELF,
+  ShieldedTokenHarness,
+  commitCoin,
+  evolveNonce,
+  hashBytes32,
+  publicKey,
+  sendImmediateShielded,
+  sendShielded,
+  shieldedBurnAddress,
+  tokenType,
+  type QualifiedShieldedCoinInfo,
+} from "../src/model/shielded-token-model.js";
+
+const DOMAIN = hashBytes32("la-tanda:shielded-token");
+const NONCE = hashBytes32("nonce:0");
+const SEED = hashBytes32("private-nonce-seed");
+const ALICE = publicKey("alice");
+const BOB = publicKey("bob");
+
+describe("shielded token lifecycle model", () => {
+  it("mints a shielded coin to the contract with the expected color", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    const coin = harness.mintToContract(1000n, NONCE);
+
+    expect(coin).toMatchObject({
+      nonce: NONCE,
+      color: tokenType(DOMAIN),
+      value: 1000n,
+      recipient: CONTRACT_SELF,
+    });
+    expect(harness.mintedOperations).toBe(1);
+  });
+
+  it("derives deterministic unique nonces with evolveNonce", () => {
+    const first = evolveNonce(0n, SEED);
+    const second = evolveNonce(1n, SEED);
+
+    expect(first).not.toEqual(second);
+    expect(evolveNonce(0n, SEED)).toEqual(first);
+  });
+
+  it("supports local nonce minting without reusing the seed directly", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    const first = harness.mintWithLocalNonce(10n, SEED, 0n);
+    const second = harness.mintWithLocalNonce(10n, SEED, 1n);
+
+    expect(first.nonce).toEqual(evolveNonce(0n, SEED));
+    expect(second.nonce).toEqual(evolveNonce(1n, SEED));
+    expect(first.nonce).not.toEqual(second.nonce);
+  });
+
+  it("requires a committed Merkle position before sendShielded can spend a coin", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const fresh = harness.mintToContract(25n, NONCE);
+
+    expect(() =>
+      sendShielded(fresh as unknown as QualifiedShieldedCoinInfo, ALICE, 5n),
+    ).toThrow(/mtIndex/);
+  });
+
+  it("commits a fresh coin into a QualifiedShieldedCoinInfo with mtIndex", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const fresh = harness.mintToContract(25n, NONCE);
+
+    const qualified = harness.commit(fresh);
+
+    expect(qualified.mtIndex).toBe(0n);
+    expect(qualified.value).toBe(25n);
+  });
+
+  it("transfers a partial amount and returns contract-owned change", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(100n, NONCE));
+
+    const result = harness.sendCommitted(qualified, ALICE, 35n);
+
+    expect(result.sent).toMatchObject({
+      value: 35n,
+      color: qualified.color,
+      recipient: ALICE,
+    });
+    expect(result.change).toMatchObject({
+      value: 65n,
+      color: qualified.color,
+      recipient: CONTRACT_SELF,
+    });
+    expect(result.sent.nonce).not.toEqual(result.change?.nonce);
+  });
+
+  it("transfers an exact amount without change", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(100n, NONCE));
+
+    const result = harness.sendCommitted(qualified, ALICE, 100n);
+
+    expect(result.sent.value).toBe(100n);
+    expect(result.change).toBeNull();
+  });
+
+  it("rejects a committed transfer that exceeds the input value", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(100n, NONCE));
+
+    expect(() => harness.sendCommitted(qualified, ALICE, 101n)).toThrow(
+      /exceeds coin value/,
+    );
+  });
+
+  it("rejects zero-value mint and send operations", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(1n, NONCE));
+
+    expect(() => harness.mintToContract(0n, NONCE)).toThrow(/non-zero/);
+    expect(() => harness.sendCommitted(qualified, ALICE, 0n)).toThrow(/non-zero/);
+  });
+
+  it("burns committed coins by sending to shieldedBurnAddress", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(90n, NONCE));
+
+    const result = harness.burnCommitted(qualified, 40n);
+
+    expect(result.sent).toMatchObject({
+      value: 40n,
+      recipient: BURN_ADDRESS,
+    });
+    expect(result.change?.value).toBe(50n);
+    expect(harness.totalBurned).toBe(40n);
+    expect(shieldedBurnAddress()).toEqual(BURN_ADDRESS);
+  });
+
+  it("burns a freshly minted coin with sendImmediateShielded", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    const result = harness.burnFresh(75n, NONCE, 75n);
+
+    expect(result.sent).toMatchObject({
+      value: 75n,
+      recipient: BURN_ADDRESS,
+    });
+    expect(result.change).toBeNull();
+    expect(harness.totalBurned).toBe(75n);
+  });
+
+  it("returns change when burning part of a freshly minted coin", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    const result = harness.burnFresh(75n, NONCE, 25n);
+
+    expect(result.sent.value).toBe(25n);
+    expect(result.change).toMatchObject({
+      value: 50n,
+      recipient: CONTRACT_SELF,
+    });
+  });
+
+  it("rejects an over-burn from a fresh coin", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    expect(() => harness.burnFresh(75n, NONCE, 76n)).toThrow(/exceeds coin value/);
+  });
+
+  it("performs atomic mint_and_send without a Merkle index", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    const result = harness.mintAndSend(120n, NONCE, ALICE, 45n);
+
+    expect(result.sent).toMatchObject({
+      value: 45n,
+      recipient: ALICE,
+      color: tokenType(DOMAIN),
+    });
+    expect(result.change?.value).toBe(75n);
+  });
+
+  it("rejects atomic mint_and_send when sendValue exceeds mintValue", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+
+    expect(() => harness.mintAndSend(120n, NONCE, ALICE, 121n)).toThrow(
+      /exceeds coin value/,
+    );
+  });
+
+  it("allows change from one transaction to be committed and spent later", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = harness.commit(harness.mintToContract(100n, NONCE));
+    const first = harness.sendCommitted(qualified, ALICE, 30n);
+
+    const change = harness.commit(first.change!);
+    const second = harness.sendCommitted(change, BOB, 20n);
+
+    expect(second.sent).toMatchObject({
+      value: 20n,
+      recipient: BOB,
+    });
+    expect(second.change?.value).toBe(50n);
+  });
+
+  it("supports direct immediate sends for coins produced in the same transaction", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const fresh = harness.mintToContract(60n, hashBytes32("nonce:immediate"));
+
+    const result = sendImmediateShielded(fresh, ALICE, 10n);
+
+    expect(result.sent.recipient).toEqual(ALICE);
+    expect(result.change?.recipient).toEqual(CONTRACT_SELF);
+  });
+
+  it("preserves coin color across send, burn, and change outputs", () => {
+    const harness = new ShieldedTokenHarness(DOMAIN);
+    const qualified = commitCoin(harness.mintToContract(100n, NONCE), 8n);
+
+    const send = harness.sendCommitted(qualified, ALICE, 25n);
+    const burn = harness.burnCommitted(harness.commit(send.change!), 10n);
+
+    expect(send.sent.color).toEqual(tokenType(DOMAIN));
+    expect(send.change?.color).toEqual(tokenType(DOMAIN));
+    expect(burn.sent.color).toEqual(tokenType(DOMAIN));
+    expect(burn.change?.color).toEqual(tokenType(DOMAIN));
+  });
+});

--- a/bounties/327-shielded-token-operations/tsconfig.json
+++ b/bounties/327-shielded-token-operations/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Submission for #327 covering shielded token mint, transfer, burn, nonce handling, change handling, and Merkle timing.

Adds a self-contained package under `bounties/327-shielded-token-operations/` with:

- Compact contract for `mint_to_contract`, `mint_with_local_nonce`, `send_committed`, `burn_committed`, `burn_fresh`, and `mint_and_send`
- TypeScript witness implementation for local nonce seed management
- Deterministic TypeScript shielded-token lifecycle model
- Vitest suite covering mint/transfer/burn, exact and partial sends, change reuse, over-spend/over-burn rejection, zero-value rejection, fresh-vs-committed Merkle timing, and burn address handling
- Tutorial in the requested 2,500-3,500 word range
- Local Apache-2.0 license coverage for config files that cannot carry comments

## Verification

- Hosted Compact compiler validation: passed with compiler `0.30.0` via the public Compact playground service
- `npm run typecheck`: passed
- `npm test`: passed, 18 tests
