### PR TITLE
docs: add Error 1010 debugging tutorial

### DIFF
--- a/tutorials/decoding-error-1010-invalid-transaction.md
+++ b/tutorials/decoding-error-1010-invalid-transaction.md
@@ -1,0 +1,176 @@
+# Decoding Error 1010: What "Invalid Transaction" Actually Means
+
+`Error 1010` is one of the least useful blockchain errors because it sounds specific while hiding the real cause.
+
+In practice, `Invalid Transaction` usually means a validation assumption failed somewhere between:
+
+- transaction construction,
+- wallet synchronization,
+- fee balancing,
+- witness generation,
+- or network acceptance.
+
+This tutorial turns the vague error into a debugging workflow you can actually use.
+
+## 1. Treat Error 1010 as a Category, Not a Diagnosis
+
+The first mistake is reading `Invalid Transaction` as a root cause. It is not.
+
+It is better to read it as:
+
+> Some assumption about transaction validity is wrong. Find the assumption.
+
+That mindset change matters because it stops you from debugging randomly.
+
+## 2. Split the Problem Into Two Phases
+
+Ask this first:
+
+### Was the transaction invalid **before** submission?
+
+This usually points to:
+
+- malformed arguments,
+- mismatched witness data,
+- stale private/public state assumptions,
+- or balancing/signing against the wrong context.
+
+### Or did it become invalid **at** submission time?
+
+This usually points to:
+
+- wallet sync drift,
+- nonce or replay-related state,
+- outdated ledger state,
+- resource limits,
+- or effects that no longer match the latest chain view.
+
+This split tells you whether to inspect your construction pipeline or your execution environment first.
+
+## 3. Check Wallet Sync Before Anything Else
+
+A large percentage of transaction errors are really sync errors wearing a different label.
+
+If wallet state is behind, then:
+
+- balances can be stale,
+- private state can be stale,
+- nullifier assumptions can be stale,
+- and transactions that looked valid a moment ago can fail now.
+
+Before touching the contract logic, confirm:
+
+- wallet is fully synced,
+- correct account context is selected,
+- and the transaction is being prepared against current state.
+
+If you skip this, you can spend an hour debugging a contract call that was never the real problem.
+
+## 4. Validate Transaction Inputs Explicitly
+
+The next class of failures is bad transaction inputs.
+
+That includes:
+
+- wrong field types,
+- missing values,
+- values outside allowed ranges,
+- or witness assumptions that no longer match current state.
+
+Useful debug log checklist before proof generation or submission:
+
+- contract address
+- method name
+- selected account / wallet
+- public arguments
+- private inputs / witness assumptions
+- expected state dependencies
+- balancing mode / sponsorship assumptions
+
+A lot of `Invalid Transaction` incidents become obvious when you log the full intent and compare it to the contract definition.
+
+## 5. Re-check Balancing and Fee Context
+
+Another common source of failure is transaction balancing in the wrong order.
+
+Examples:
+
+- balancing too early,
+- mutating the payload after balancing,
+- using the wrong token kinds,
+- sponsorship flow not matching the final transaction shape.
+
+If your flow includes multiple preparation steps, the rule should be:
+
+> finalize transaction shape first, then balance, then sign/submit.
+
+Otherwise you can easily produce a transaction that was once valid but is no longer valid after a later mutation.
+
+## 6. Compare Against the Last Known-Good Transaction
+
+One of the fastest ways to debug `Invalid Transaction` is to compare the failing transaction with the last successful one.
+
+Look for differences in:
+
+- method name
+- argument shape
+- account context
+- balance state
+- sponsorship / fee path
+- contract state dependency
+
+Do not compare large workflows abstractly. Compare concrete transaction shapes.
+
+That usually shrinks the search space dramatically.
+
+## 7. Build a Minimal Reproduction
+
+If the error keeps happening, reduce the transaction until only the essential failing shape remains.
+
+Your minimal repro should answer:
+
+- smallest contract call that still fails
+- smallest input set that still fails
+- smallest wallet state needed to trigger it
+- exact point where the transaction becomes invalid
+
+This helps both your own debugging and any later maintainer support request.
+
+## 8. A Practical Debugging Sequence
+
+Use this order every time:
+
+1. Confirm wallet sync
+2. Confirm account / signer context
+3. Confirm contract method and argument types
+4. Confirm witness/state assumptions
+5. Confirm balancing order and fee path
+6. Compare with last known-good transaction
+7. Reduce to minimal reproduction
+
+That order catches the highest-frequency causes early.
+
+## 9. A Useful Mental Model for Midnight Developers
+
+For Midnight-style flows, `Invalid Transaction` often means one of these broad categories:
+
+- **state mismatch** — your local assumptions are behind chain reality
+- **construction mismatch** — your transaction shape doesn't match contract expectations
+- **resource mismatch** — the transaction is too expensive or otherwise violates execution constraints
+- **effects mismatch** — the intended result cannot be validated against current ledger state
+
+You do not need the error string to be perfect if your debugging model is strong.
+
+## 10. Final Checklist
+
+Before escalating an `Error 1010` issue, verify all of these:
+
+- wallet is fully synced
+- correct account / signer is selected
+- contract arguments match expected types
+- witness and state assumptions are current
+- transaction shape stopped changing before balancing
+- fee / sponsorship path matches final transaction
+- failure reproduced with minimal case
+
+Once you can answer those clearly, `Invalid Transaction` stops being mysterious and becomes just another debugging problem.


### PR DESCRIPTION
Fixes #318

This adds a practical tutorial draft for decoding `Error 1010 / Invalid Transaction` in Midnight workflows.

Focus areas:
- why the error should be treated as a category, not a diagnosis
- how to split construction-time vs submission-time failures
- why wallet sync is the first thing to check
- validating transaction intent and balancing order
- building a minimal reproduction before escalation
