### PR TITLE
Add DUST sponsorship tutorial

### DIFF
--- a/examples/dust-sponsorship/.gitignore
+++ b/examples/dust-sponsorship/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/dust-sponsorship/README.md
+++ b/examples/dust-sponsorship/README.md
@@ -1,0 +1,26 @@
+<!--
+This file is part of contributor-hub.
+Copyright (C) 2026 Midnight Foundation
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0.
+-->
+
+# DUST sponsorship example
+
+This is a minimal, typecheckable boundary example for a Midnight DUST sponsor
+service. It intentionally uses structural TypeScript interfaces instead of
+importing the Wallet SDK, so the policy and DUST-only balancing behavior can be
+tested without network keys, a proof server, or package registry access to the
+official SDK.
+
+In a real integration, the `SponsorWallet` implementation should be a
+`WalletFacade` from `@midnight-ntwrk/wallet-sdk-facade`, initialized with the
+official Wallet SDK packages listed in `../../tutorials/dust-sponsorship.md`.
+
+## Validate
+
+```sh
+npm install
+npm run typecheck
+npm test
+```

--- a/examples/dust-sponsorship/package-lock.json
+++ b/examples/dust-sponsorship/package-lock.json
@@ -1,0 +1,590 @@
+{
+  "name": "midnight-dust-sponsorship-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "midnight-dust-sponsorship-example",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.0.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/dust-sponsorship/package.json
+++ b/examples/dust-sponsorship/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "midnight-dust-sponsorship-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal typecheckable DUST sponsorship boundary example for Midnight Wallet SDK integrations.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "node --test --import tsx src/sponsor-service.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/examples/dust-sponsorship/src/sponsor-service.test.ts
+++ b/examples/dust-sponsorship/src/sponsor-service.test.ts
@@ -1,0 +1,96 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2026 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DustSponsorService,
+  SponsorshipError,
+  type SponsorPolicy,
+  type SponsorWallet,
+} from './sponsor-service.js';
+
+const policy: SponsorPolicy = {
+  networkId: 'preprod',
+  ttlMilliseconds: 30 * 60 * 1000,
+  allow: async () => true,
+};
+
+function walletWithDust(balance: bigint): SponsorWallet & { tokenKinds: string[] } {
+  const observed = { tokenKinds: [] as string[] };
+
+  return {
+    ...observed,
+    waitForSyncedState: async () => ({
+      dust: {
+        totalCoins: balance,
+      },
+    }),
+    balanceFinalizedTransaction: async (_tx, _secrets, options) => {
+      observed.tokenKinds.push(...options.tokenKindsToBalance);
+      return { recipe: true };
+    },
+    signRecipe: async (recipe) => ({ recipe, signed: true }),
+    finalizeRecipe: async (recipe) => ({ recipe, finalized: true }),
+    submitTransaction: async () => 'tx-123',
+  };
+}
+
+test('sponsors finalized transactions by balancing only dust', async () => {
+  const wallet = walletWithDust(1n);
+  const service = new DustSponsorService(
+    wallet,
+    { shieldedSecretKeys: {}, dustSecretKey: {} },
+    async (payload) => payload,
+    policy,
+  );
+
+  const result = await service.sponsor({
+    idempotencyKey: 'request-1',
+    networkId: 'preprod',
+    finalizedTransaction: { tx: true },
+  });
+
+  assert.deepEqual(result, { requestId: 'request-1', transactionId: 'tx-123' });
+  assert.deepEqual(wallet.tokenKinds, ['dust']);
+});
+
+test('rejects when the sponsor has no visible dust capacity', async () => {
+  const service = new DustSponsorService(
+    walletWithDust(0n),
+    { shieldedSecretKeys: {}, dustSecretKey: {} },
+    async (payload) => payload,
+    policy,
+  );
+
+  await assert.rejects(
+    () =>
+      service.sponsor({
+        idempotencyKey: 'request-2',
+        networkId: 'preprod',
+        finalizedTransaction: { tx: true },
+      }),
+    (error) => error instanceof SponsorshipError && error.code === 'SPONSOR_DUST_UNAVAILABLE',
+  );
+});
+
+test('rejects unsupported networks before balancing', async () => {
+  const service = new DustSponsorService(
+    walletWithDust(1n),
+    { shieldedSecretKeys: {}, dustSecretKey: {} },
+    async (payload) => payload,
+    policy,
+  );
+
+  await assert.rejects(
+    () =>
+      service.sponsor({
+        idempotencyKey: 'request-3',
+        networkId: 'preview',
+        finalizedTransaction: { tx: true },
+      }),
+    (error) => error instanceof SponsorshipError && error.code === 'UNSUPPORTED_NETWORK',
+  );
+});

--- a/examples/dust-sponsorship/src/sponsor-service.ts
+++ b/examples/dust-sponsorship/src/sponsor-service.ts
@@ -1,0 +1,119 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2026 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0.
+
+export type TokenKind = 'shielded' | 'unshielded' | 'dust';
+
+export type BalanceOptions = {
+  ttl: Date;
+  tokenKindsToBalance: readonly TokenKind[];
+};
+
+export type SponsorshipRequest = {
+  idempotencyKey: string;
+  networkId: string;
+  finalizedTransaction: unknown;
+};
+
+export type SponsorshipResult = {
+  requestId: string;
+  transactionId: string;
+};
+
+export type SponsorSecrets = {
+  shieldedSecretKeys: unknown;
+  dustSecretKey: unknown;
+};
+
+export type SponsorPolicy = {
+  networkId: string;
+  ttlMilliseconds: number;
+  allow(request: SponsorshipRequest): Promise<boolean>;
+};
+
+export type SponsorWallet = {
+  waitForSyncedState(): Promise<{ dust: { totalCoins: bigint } }>;
+  balanceFinalizedTransaction(
+    finalizedTransaction: unknown,
+    secretKeys: SponsorSecrets,
+    options: BalanceOptions,
+  ): Promise<unknown>;
+  signRecipe(recipe: unknown, sign: (payload: Uint8Array) => Promise<Uint8Array>): Promise<unknown>;
+  finalizeRecipe(recipe: unknown): Promise<unknown>;
+  submitTransaction(transaction: unknown): Promise<string>;
+};
+
+export class SponsorshipError extends Error {
+  constructor(
+    readonly code:
+      | 'SPONSOR_DUST_UNAVAILABLE'
+      | 'UNSUPPORTED_NETWORK'
+      | 'POLICY_REJECTED'
+      | 'INVALID_REQUEST',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SponsorshipError';
+  }
+}
+
+export class DustSponsorService {
+  constructor(
+    private readonly wallet: SponsorWallet,
+    private readonly secrets: SponsorSecrets,
+    private readonly signSponsorPayload: (payload: Uint8Array) => Promise<Uint8Array>,
+    private readonly policy: SponsorPolicy,
+  ) {}
+
+  async sponsor(request: SponsorshipRequest): Promise<SponsorshipResult> {
+    this.validateRequest(request);
+
+    if (request.networkId !== this.policy.networkId) {
+      throw new SponsorshipError(
+        'UNSUPPORTED_NETWORK',
+        `Expected ${this.policy.networkId}, received ${request.networkId}.`,
+      );
+    }
+
+    if (!(await this.policy.allow(request))) {
+      throw new SponsorshipError('POLICY_REJECTED', 'The sponsor policy rejected this transaction.');
+    }
+
+    const synced = await this.wallet.waitForSyncedState();
+    if (synced.dust.totalCoins <= 0n) {
+      throw new SponsorshipError('SPONSOR_DUST_UNAVAILABLE', 'The sponsor wallet has no usable DUST.');
+    }
+
+    const recipe = await this.wallet.balanceFinalizedTransaction(
+      request.finalizedTransaction,
+      this.secrets,
+      {
+        ttl: new Date(Date.now() + this.policy.ttlMilliseconds),
+        tokenKindsToBalance: ['dust'],
+      },
+    );
+    const signedRecipe = await this.wallet.signRecipe(recipe, this.signSponsorPayload);
+    const transaction = await this.wallet.finalizeRecipe(signedRecipe);
+    const transactionId = await this.wallet.submitTransaction(transaction);
+
+    return {
+      requestId: request.idempotencyKey,
+      transactionId,
+    };
+  }
+
+  private validateRequest(request: SponsorshipRequest): void {
+    if (request.idempotencyKey.trim().length === 0) {
+      throw new SponsorshipError('INVALID_REQUEST', 'Missing idempotency key.');
+    }
+
+    if (request.networkId.trim().length === 0) {
+      throw new SponsorshipError('INVALID_REQUEST', 'Missing network id.');
+    }
+
+    if (request.finalizedTransaction == null) {
+      throw new SponsorshipError('INVALID_REQUEST', 'Missing finalized transaction.');
+    }
+  }
+}

--- a/examples/dust-sponsorship/tsconfig.json
+++ b/examples/dust-sponsorship/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tutorials/dust-sponsorship.md
+++ b/tutorials/dust-sponsorship.md
@@ -1,0 +1,305 @@
+<!--
+This file is part of contributor-hub.
+Copyright (C) 2026 Midnight Foundation
+SPDX-License-Identifier: Apache-2.0
+Licensed under the Apache License, Version 2.0.
+-->
+
+# DUST sponsorship on Midnight
+
+DUST sponsorship lets a service pay the transaction fee for a user without taking
+over the user's proof, wallet identity, or contract-level authority. The user
+still builds the transaction with their own wallet context. The sponsor only adds
+DUST for fees and then submits the finished transaction.
+
+This tutorial uses the current Wallet SDK concepts documented in the Midnight
+wallet developer guide: `WalletFacade`, the unshielded, shielded, and DUST wallet
+roles, `balanceUnboundTransaction`, `balanceFinalizedTransaction`,
+`finalizeRecipe`, `signRecipe`, and `submitTransaction`. The official packages
+for these operations are `@midnight-ntwrk/wallet-sdk-facade`,
+`@midnight-ntwrk/wallet-sdk-unshielded-wallet`,
+`@midnight-ntwrk/wallet-sdk-shielded`,
+`@midnight-ntwrk/wallet-sdk-dust-wallet`, `@midnight-ntwrk/wallet-sdk-hd`,
+`@midnight-ntwrk/wallet-sdk-address-format`, and `@midnight-ntwrk/ledger-v8`.
+
+The important API shape is the balancing option:
+
+```ts
+{
+  ttl: new Date(Date.now() + 30 * 60 * 1000),
+  tokenKindsToBalance: ['dust'],
+}
+```
+
+Use that option only at the sponsorship step. The user side should not ask its
+wallet to add DUST if the user has none.
+
+## When to use sponsorship
+
+Sponsorship is useful when a DApp wants a smoother first transaction for users
+who do not yet have DUST, or when an operator wants to subsidize a specific
+workflow. It is not a direct DUST transfer pattern. The sponsor is not sending
+spendable DUST to the user. Instead, the sponsor wallet contributes DUST inputs
+to one transaction it is willing to pay for.
+
+The sponsor also does not become the contract caller merely by paying fees. If a
+Compact circuit calls `ownPublicKey()`, it retrieves the Zswap coin public key of
+the user executing the circuit. In a sponsored flow, that should be the prover's
+key from the user's transaction-building context, not the sponsor's DUST key. Do
+not write contract authorization logic that assumes the fee payer is the actor.
+
+## Flow
+
+The current Wallet SDK documentation describes a three-step two-party flow: the
+user balances non-DUST token kinds, the sponsor adds DUST to the finalized
+transaction, and the sponsor submits it.
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant UserWallet
+  participant SponsorAPI
+  participant SponsorWallet
+  participant Network
+
+  User->>UserWallet: Build transaction intent
+  UserWallet->>UserWallet: balanceUnboundTransaction(..., tokenKindsToBalance: ['shielded', 'unshielded'])
+  UserWallet->>UserWallet: signRecipe and finalizeRecipe
+  User->>SponsorAPI: POST finalized transaction
+  SponsorAPI->>SponsorWallet: validate request and policy
+  SponsorWallet->>SponsorWallet: balanceFinalizedTransaction(..., tokenKindsToBalance: ['dust'])
+  SponsorWallet->>Network: submitTransaction
+  Network-->>SponsorAPI: transaction id or rejection
+  SponsorAPI-->>User: sponsorship result
+```
+
+If your service owns an unbound transaction construction path internally, the
+same sponsor-only restriction applies with `balanceUnboundTransaction`:
+
+```ts
+const dustOnlyRecipe = await sponsorWallet.balanceUnboundTransaction(
+  unboundTransaction,
+  { shieldedSecretKeys: sponsorShieldedKeys, dustSecretKey: sponsorDustKey },
+  {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+    tokenKindsToBalance: ['dust'],
+  },
+);
+```
+
+For a normal user-to-sponsor handoff, prefer the documented
+`balanceFinalizedTransaction` shape because the user's proofs and signatures have
+already been produced before the sponsor receives the transaction.
+
+## User-side preparation
+
+The user wallet starts from a transaction intent created by the DApp. That may be
+a contract call, shielded transfer, or another wallet-supported operation. The
+user wallet should balance only the token kinds the user is responsible for:
+
+```ts
+const userRecipe = await userWallet.balanceUnboundTransaction(
+  transaction,
+  { shieldedSecretKeys: userShieldedKeys, dustSecretKey: userDustKey },
+  {
+    ttl: new Date(Date.now() + 30 * 60 * 1000),
+    tokenKindsToBalance: ['shielded', 'unshielded'],
+  },
+);
+
+const userSigned = await userWallet.signRecipe(userRecipe, (payload) =>
+  userKeystore.signData(payload),
+);
+
+const userFinalized = await userWallet.finalizeRecipe(userSigned);
+```
+
+The `userFinalized` value is what the client sends to the sponsor service. Keep
+the request small and explicit. Include the serialized finalized transaction, an
+idempotency key, the expected network, and any DApp-level context the sponsor
+uses for policy checks. Do not include private keys or local wallet state.
+
+## Sponsor service
+
+A sponsor service has three jobs: validate, balance DUST only, and submit. The
+example below uses structural types so the flow is clear. In a real service,
+`wallet` is a `WalletFacade` created from the official Wallet SDK packages and
+initialized with the sponsor's shielded and DUST keys.
+
+```ts
+type TokenKind = 'shielded' | 'unshielded' | 'dust';
+
+type BalanceOptions = {
+  ttl: Date;
+  tokenKindsToBalance: TokenKind[];
+};
+
+type SponsorWallet = {
+  waitForSyncedState(): Promise<{ dust: { totalCoins: bigint } }>;
+  balanceFinalizedTransaction(
+    finalizedTransaction: unknown,
+    secretKeys: { shieldedSecretKeys: unknown; dustSecretKey: unknown },
+    options: BalanceOptions,
+  ): Promise<unknown>;
+  signRecipe(recipe: unknown, sign: (payload: Uint8Array) => Promise<Uint8Array>): Promise<unknown>;
+  finalizeRecipe(recipe: unknown): Promise<unknown>;
+  submitTransaction(transaction: unknown): Promise<string>;
+};
+
+async function sponsorTransaction(input: {
+  wallet: SponsorWallet;
+  finalizedTransaction: unknown;
+  sponsorShieldedKeys: unknown;
+  sponsorDustKey: unknown;
+  signSponsorPayload: (payload: Uint8Array) => Promise<Uint8Array>;
+}) {
+  const synced = await input.wallet.waitForSyncedState();
+  const visibleDust = synced.dust.totalCoins;
+
+  if (visibleDust <= 0n) {
+    throw new Error('SPONSOR_DUST_UNAVAILABLE');
+  }
+
+  const recipe = await input.wallet.balanceFinalizedTransaction(
+    input.finalizedTransaction,
+    {
+      shieldedSecretKeys: input.sponsorShieldedKeys,
+      dustSecretKey: input.sponsorDustKey,
+    },
+    {
+      ttl: new Date(Date.now() + 30 * 60 * 1000),
+      tokenKindsToBalance: ['dust'],
+    },
+  );
+
+  const signed = await input.wallet.signRecipe(recipe, input.signSponsorPayload);
+  const ready = await input.wallet.finalizeRecipe(signed);
+
+  return input.wallet.submitTransaction(ready);
+}
+```
+
+Production services should add request authentication, per-user and global rate
+limits, idempotency storage, input size limits, network checks, and a policy
+layer that decides which contract calls are eligible. Do those checks before
+balancing. The sponsor should never pay for an opaque transaction just because it
+is syntactically valid.
+
+## The `ownPublicKey()` caveat
+
+`ownPublicKey()` is a Compact runtime function. It returns the Zswap coin public
+key for the user executing the circuit. Sponsorship does not make the sponsor the
+executor of the user's private circuit. The sponsor is a fee payer at the wallet
+transaction layer.
+
+That distinction affects authorization. If your contract stores an owner key and
+checks it against `ownPublicKey()`, the check should still evaluate against the
+user who proved the circuit. If the sponsor's key appeared there, sponsorship
+would accidentally change the actor. That is not the model you should design
+for. Keep sponsor policy outside the circuit, and keep user authority inside the
+user's proof and signatures.
+
+## What each side can see
+
+The user can see their own wallet state, private inputs, and whether the sponsor
+accepted or rejected the request. The user should not be able to inspect the
+sponsor's DUST balance unless the sponsor chooses to publish service health.
+
+The sponsor can see what is present in the finalized transaction and the metadata
+the client sends to the API. The sponsor cannot recover the user's private
+witnesses or local private state from the sponsorship request. Because DUST is
+managed by the DUST wallet, only the wallet with the relevant DUST secret key can
+check that wallet's DUST balance directly.
+
+## Service boundaries
+
+Keep the sponsorship API boring. A useful endpoint is `POST /sponsor` with a
+body containing `{ idempotencyKey, networkId, finalizedTransaction }`. The
+response can be `{ requestId, transactionId }` on success or a stable error code
+on failure. Idempotency matters because clients may retry after a timeout while
+the original request is still being balanced or submitted. Store the request id
+with the transaction hash once submission succeeds.
+
+The sponsor should also expose a coarse health endpoint, such as
+`GET /sponsor/health`, but avoid publishing exact wallet balances unless your
+operations policy requires it. A simple `available`, `limited`, or `unavailable`
+status is usually enough for clients to decide whether to submit a request or
+ask the user to try later.
+
+## DUST generation, depletion, and recovery
+
+DUST is required for transaction fees and is generated from registered NIGHT
+holdings. The Wallet SDK guide shows registration with
+`registerNightUtxosForDustGeneration`, after which generation begins once the
+blockchain processes the registration. The guide also shows that wallet state can
+report DUST with `state.dust.balance(new Date())`.
+
+Avoid hard-coding economic constants or promising a number of sponsored
+transactions per NIGHT unless you have current network parameters from an
+official source for the environment you are targeting. For operational code,
+treat DUST as capacity that can be available, low, or unavailable. If the sponsor
+wallet has registered NIGHT and no DUST yet, wait for generation. If DUST was
+spent faster than it is generated, reject or queue sponsorship requests until the
+wallet reports enough DUST again. If the service has no registered NIGHT
+generating DUST to the sponsor's DUST address, there is nothing for the sponsor
+wallet to add.
+
+## Expected failure modes
+
+`SPONSOR_DUST_UNAVAILABLE`: the sponsor wallet is synced but reports no usable
+DUST for the request. Retry only after the sponsor reports capacity.
+
+`UNSUPPORTED_NETWORK`: the request targets a network other than the sponsor's
+configured network, such as mixing Preview and Preprod.
+
+`POLICY_REJECTED`: the transaction is outside the sponsor's allowlist, exceeds a
+per-user quota, or is missing required DApp metadata.
+
+`TX_EXPIRED`: the transaction TTL was too short or the sponsor processed it too
+late.
+
+`BALANCING_FAILED`: the SDK could not add DUST inputs, often because DUST changed
+while the request was waiting or the transaction was already unsuitable for
+balancing.
+
+`SUBMISSION_REJECTED`: the node rejected the transaction after finalization.
+Return the rejection category and let the user rebuild a fresh transaction.
+
+## Validation
+
+For the companion example in this repository:
+
+```sh
+cd examples/dust-sponsorship
+npm install
+npm run typecheck
+npm test
+```
+
+For a real Wallet SDK integration, also run your normal Midnight application
+tests against the target environment, start from a synced sponsor wallet, verify
+that the user can submit a zero-DUST request, and verify that the same request
+fails cleanly when the sponsor wallet reports no DUST.
+
+## Checklist
+
+Before using sponsorship in production:
+
+- Initialize the sponsor wallet from official Wallet SDK packages.
+- Confirm the sponsor is synced before balancing or submitting.
+- Balance only `['dust']` in the sponsor step.
+- Keep user proof generation and `ownPublicKey()` authority with the user.
+- Limit sponsorship to known transactions and known networks.
+- Log request ids and transaction ids, not private wallet state.
+- Return clear retry guidance for DUST, TTL, balancing, and submission failures.
+
+## References
+
+- Midnight Wallet SDK guide:
+  <https://docs.midnight.network/sdks/official/wallet-developer-guide>
+- `ownPublicKey()` Compact runtime reference:
+  <https://docs.midnight.network/api-reference/compact-runtime/functions/ownPublicKey>
+- Midnight compatibility matrix:
+  <https://docs.midnight.network/relnotes/support-matrix>
+- Programmatic DUST generation guide:
+  <https://docs.midnight.network/guides/generating-dust-programmatically>


### PR DESCRIPTION
## Summary

Adds a DUST sponsorship tutorial for Midnight #299 and a minimal companion TypeScript example.

## What Changed

- Added tutorials/dust-sponsorship.md, a 1,597-word tutorial covering the current Wallet SDK sponsorship flow.
- Documented the DUST-only sponsorship step, ownPublicKey() behavior, sponsor/user visibility limits, failure modes, validation commands, and official references.
- Added examples/dust-sponsorship, a typecheckable boundary example that models sponsor policy and DUST-only balancing without claiming to be a live WalletFacade integration.

## Validation

Run in examples/dust-sponsorship:

npm install
npm run typecheck
npm test

Results before opening this PR:

- npm install: passed, 0 vulnerabilities
- npm run typecheck: passed
- npm test: passed, 3 tests passing
- wc -w tutorials/dust-sponsorship.md: 1,597 words
- git diff --cached --check: passed before commit

## Notes

The example intentionally uses structural TypeScript interfaces so it can be tested in this repository without live Midnight keys, a proof server, or a full Wallet SDK runtime setup.