### PR TITLE
Add Witnesses in Depth tutorial (#291)

### DIFF
--- a/tutorials/witnesses-in-depth/README.md
+++ b/tutorials/witnesses-in-depth/README.md
@@ -1,0 +1,71 @@
+# Witnesses in Depth — Midnight Network Tutorial
+
+> A comprehensive guide to understanding, implementing, and using **Witnesses** in the Midnight Network smart contract ecosystem.
+
+## About This Tutorial
+
+Witnesses are one of the most powerful yet often misunderstood concepts in Midnight's zero-knowledge contract architecture. They serve as the bridge between on-chain state and off-chain computation, enabling contracts to access persistent data during proof generation without revealing that data on-chain.
+
+This tutorial dives deep into the witness pattern, explores all witness types, and provides hands-on code examples you can run and extend.
+
+## Prerequisites
+
+- Familiarity with TypeScript / JavaScript
+- Basic understanding of zero-knowledge proofs (ZKPs)
+- [Midnight Compact compiler](https://docs.midnight.network/) installed
+- Node.js 18+ and npm/yarn
+
+## Tutorial Contents
+
+| Section | Description |
+|---------|-------------|
+| [Witnesses in Depth](./witnesses-in-depth.md) | Full tutorial covering witness theory, patterns, types, and real-world use cases |
+| [Examples](./examples/) | Runnable code samples demonstrating each witness pattern |
+
+## Code Examples
+
+- **`basic-witnesses.compact`** — Core witness declarations and usage in Compact
+- **`witness-provider.ts`** — TypeScript witness provider implementation
+- **`merkle-witness.compact`** — Merkle tree witness for authenticated data structures
+- **`merkle-witness-provider.ts`** — TypeScript Merkle witness provider
+- **`counter-witness.compact`** — Stateful witness pattern with counter logic
+- **`counter-witness-provider.ts`** — TypeScript counter witness provider with persistence
+
+## Quick Start
+
+```bash
+# Clone the contributor-hub repo
+git clone https://github.com/midnightntwrk/contributor-hub.git
+cd contributor-hub/tutorials/witnesses-in-depth/examples
+
+# Install dependencies (if running TypeScript examples)
+npm install
+
+# Compile a Compact contract
+compact compile basic-witnesses.compact
+
+# Run the TypeScript witness provider
+npx ts-node witness-provider.ts
+```
+
+## Key Concepts at a Glance
+
+- **Witness**: A value supplied off-chain that the ZK circuit uses during proof generation
+- **Witness Provider**: A TypeScript function that computes and returns the witness value
+- **Pattern**: Witnesses follow a declare-then-provide pattern across Compact and TypeScript
+- **Types**: Witnesses can be primitive, composite, Merkle-based, or stateful
+
+## Resources
+
+- [Midnight Developer Docs](https://docs.midnight.network/)
+- [Midnight Compact Language Reference](https://docs.midnight.network/compact/)
+- [Discord Community](https://discord.com/invite/midnightnetwork)
+- [GitHub — Midnight Network](https://github.com/midnightntwrk)
+
+## License
+
+This tutorial is provided under the Apache 2.0 License, consistent with the Midnight Network contributor-hub project.
+
+---
+
+*Contributed as part of [midnightntwrk/contributor-hub#291](https://github.com/midnightntwrk/contributor-hub/issues/291)*

--- a/tutorials/witnesses-in-depth/examples/basic-witnesses.compact
+++ b/tutorials/witnesses-in-depth/examples/basic-witnesses.compact
@@ -1,0 +1,71 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic Witnesses Example — Midnight Compact
+// Demonstrates: primitive, composite, and argument-free witness declarations
+
+// --- Type Definitions ---
+
+struct UserRecord {
+  balance: Field;
+  nonce: Field;
+  tier: Uint<8>;
+}
+
+// --- Witness Declarations ---
+
+// Primitive witness: returns a single Field value for a given address
+witness get_balance(owner: Address): Field;
+
+// Composite witness: returns a struct with multiple fields
+witness get_user_record(addr: Address): UserRecord;
+
+// Argument-free witness: returns a value without any input
+witness current_timestamp(): Uint<64>;
+
+// --- Contract ---
+
+contract BasicWitnesses {
+
+  ledger_root: Field;
+  last_action: Uint<64>;
+  action_count: Field;
+
+  constructor(initial_root: Field) {
+    ledger_root = initial_root;
+    last_action = 0;
+    action_count = 0;
+  }
+
+  // Transfer tokens privately — witness proves sender has funds without revealing balance
+  transition transfer(sender: Address, recipient_hash: Field, amount: Field): Field {
+    let balance: Field = get_balance(sender);
+    assert(balance >= amount, "Insufficient balance");
+
+    let now: Uint<64> = current_timestamp();
+    assert(now > last_action, "Timestamp must be monotonically increasing");
+
+    last_action = now;
+    action_count = action_count + 1;
+
+    return balance - amount;
+  }
+
+  // Upgrade user tier using composite witness
+  transition upgrade_tier(addr: Address, target_tier: Uint<8>): Boolean {
+    let record: UserRecord = get_user_record(addr);
+    assert(record.tier < target_tier, "Already at or above target tier");
+    assert(record.nonce > 0, "Account must be active");
+
+    action_count = action_count + 1;
+
+    return true;
+  }
+
+  // View: check if balance is non-zero (still uses witness for privacy)
+  transition check_balance(owner: Address): Boolean {
+    let balance: Field = get_balance(owner);
+    return balance > 0;
+  }
+}

--- a/tutorials/witnesses-in-depth/examples/counter-witness-provider.ts
+++ b/tutorials/witnesses-in-depth/examples/counter-witness-provider.ts
@@ -1,0 +1,134 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Counter / Stateful Witness Provider — TypeScript Implementation
+// Demonstrates closures that maintain mutable state across proof generations.
+
+import { WitnessProviders, Field } from "@midnight-ntwrk/compact-runtime";
+
+// --- Types ---
+
+interface ActionRecord {
+  action_id: bigint;
+  actor_hash: bigint;
+  timestamp: bigint;
+  nonce: bigint;
+}
+
+// --- Stateful Provider Factory ---
+
+interface StatefulWitnessState {
+  nonceCounter: bigint;
+  actionIdCounter: bigint;
+  lastTimestamp: bigint;
+  actionLog: ActionRecord[];
+}
+
+function createStatefulProviders(initialState?: Partial<StatefulWitnessState>) {
+  const state: StatefulWitnessState = {
+    nonceCounter: initialState?.nonceCounter ?? 0n,
+    actionIdCounter: initialState?.actionIdCounter ?? 0n,
+    lastTimestamp: initialState?.lastTimestamp ?? BigInt(Math.floor(Date.now() / 1000)),
+    actionLog: initialState?.actionLog ?? [],
+  };
+
+  const providers: WitnessProviders = {
+
+    /** Stateful: returns monotonically increasing nonce. */
+    next_nonce: (): bigint => {
+      state.nonceCounter += 1n;
+      console.log(`[next_nonce] => ${state.nonceCounter}`);
+      return state.nonceCounter;
+    },
+
+    /** Stateful: returns unique action ID. */
+    next_action_id: (): bigint => {
+      state.actionIdCounter += 1n;
+      console.log(`[next_action_id] => ${state.actionIdCounter}`);
+      return state.actionIdCounter;
+    },
+
+    /** Stateful + Composite: builds a complete ActionRecord. */
+    build_action_record: (actor_hash: bigint): ActionRecord => {
+      state.nonceCounter += 1n;
+      state.actionIdCounter += 1n;
+      state.lastTimestamp += 1n;
+
+      const record: ActionRecord = {
+        action_id: state.actionIdCounter,
+        actor_hash: actor_hash,
+        timestamp: state.lastTimestamp,
+        nonce: state.nonceCounter,
+      };
+
+      state.actionLog.push(record);
+      console.log(`[build_action_record] =>`, {
+        id: record.action_id.toString(),
+        actor: "0x" + record.actor_hash.toString(16),
+        ts: record.timestamp.toString(),
+        nonce: record.nonce.toString(),
+      });
+
+      return record;
+    },
+  };
+
+  return { providers, getState: () => ({ ...state }) };
+}
+
+// --- Demo ---
+
+function demo() {
+  console.log("=== Stateful Witness Provider Demo ===\n");
+
+  const { providers, getState } = createStatefulProviders({
+    nonceCounter: 100n,
+  });
+
+  console.log("Initial state: nonce=" + getState().nonceCounter + "\n");
+
+  console.log("--- Calling next_nonce() three times ---");
+  const n1 = providers.next_nonce();
+  const n2 = providers.next_nonce();
+  const n3 = providers.next_nonce();
+  console.log("Nonces: " + n1 + ", " + n2 + ", " + n3);
+  console.log("State after: nonce=" + getState().nonceCounter + "\n");
+
+  console.log("--- Building action records ---");
+  const actorA = 0xdeadbeefn;
+  const actorB = 0xcafebaben;
+
+  providers.build_action_record(actorA);
+  providers.build_action_record(actorB);
+  providers.build_action_record(actorA);
+
+  console.log("\n--- Action Log ---");
+  const log = getState().actionLog;
+  log.forEach((r, i) => {
+    console.log("  [" + i + "] id=" + r.action_id + " nonce=" + r.nonce +
+      " actor=0x" + r.actor_hash.toString(16) + " ts=" + r.timestamp);
+  });
+
+  console.log("\n--- Monotonicity Check ---");
+  const noncesIncreasing = log.every((r, i) => i === 0 || r.nonce > log[i - 1].nonce);
+  const timestampsIncreasing = log.every((r, i) => i === 0 || r.timestamp > log[i - 1].timestamp);
+  console.log("  Nonces strictly increasing: " + noncesIncreasing);
+  console.log("  Timestamps strictly increasing: " + timestampsIncreasing);
+
+  console.log("\n--- Independent Provider Instances ---");
+  const { providers: freshProviders } = createStatefulProviders();
+  const freshNonce = freshProviders.next_nonce();
+  console.log("  Fresh provider first nonce: " + freshNonce);
+  console.log("  Original provider last nonce: " + getState().nonceCounter);
+  console.log("  (Each instance has independent state)\n");
+
+  console.log("=== Demo Complete ===");
+}
+
+if (require.main === module) {
+  demo();
+}
+
+export { createStatefulProviders };
+export default createStatefulProviders;

--- a/tutorials/witnesses-in-depth/examples/counter-witness.compact
+++ b/tutorials/witnesses-in-depth/examples/counter-witness.compact
@@ -1,0 +1,81 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Counter / Stateful Witness Example — Midnight Compact
+// Demonstrates stateful witnesses where the provider maintains internal state
+
+// --- Types ---
+
+struct ActionRecord {
+  action_id: Field;
+  actor_hash: Field;
+  timestamp: Uint<64>;
+  nonce: Field;
+}
+
+// --- Witness Declarations ---
+
+// Stateful: returns a monotonically increasing nonce (no arguments)
+witness next_nonce(): Field;
+
+// Stateful: returns a unique action ID
+witness next_action_id(): Field;
+
+// Combined stateful + composite: builds a full ActionRecord
+witness build_action_record(actor_hash: Field): ActionRecord;
+
+// --- Circuit Functions ---
+
+fn validate_action_record(record: ActionRecord, expected_actor: Field) -> Boolean {
+  let actor_ok: Boolean = record.actor_hash == expected_actor;
+  let nonce_ok: Boolean = record.nonce > 0;
+  let id_ok: Boolean = record.action_id > 0;
+  return actor_ok && nonce_ok && id_ok;
+}
+
+// --- Contract ---
+
+contract CounterWitnessExample {
+
+  global_nonce: Field;
+  processed_actions: Field;
+  last_actor_hash: Field;
+  last_timestamp: Uint<64>;
+
+  constructor() {
+    global_nonce = 0;
+    processed_actions = 0;
+    last_actor_hash = 0;
+    last_timestamp = 0;
+  }
+
+  // Submit an action with a stateful nonce
+  transition submit_action(actor_hash: Field): Field {
+    let nonce: Field = next_nonce();
+    assert(nonce > global_nonce, "Nonce must be greater than current global nonce");
+    global_nonce = nonce;
+    processed_actions = processed_actions + 1;
+    last_actor_hash = actor_hash;
+    return nonce;
+  }
+
+  // Submit a full action record with stateful IDs and nonces
+  transition submit_full_action(actor_hash: Field): Field {
+    let record: ActionRecord = build_action_record(actor_hash);
+    let valid: Boolean = validate_action_record(record, actor_hash);
+    assert(valid, "Invalid action record");
+    assert(record.nonce > global_nonce, "Nonce must be monotonically increasing");
+    assert(record.timestamp > last_timestamp, "Timestamp must be monotonically increasing");
+    global_nonce = record.nonce;
+    processed_actions = processed_actions + 1;
+    last_actor_hash = actor_hash;
+    last_timestamp = record.timestamp;
+    return record.action_id;
+  }
+
+  // View: get current state
+  transition get_state(): [Field, Field, Field] {
+    return [global_nonce, processed_actions, last_actor_hash];
+  }
+}

--- a/tutorials/witnesses-in-depth/examples/merkle-witness-provider.ts
+++ b/tutorials/witnesses-in-depth/examples/merkle-witness-provider.ts
@@ -1,0 +1,156 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Merkle Witness Provider — TypeScript Implementation
+// Implements witness providers for merkle-witness.compact
+
+import { WitnessProviders, Field } from "@midnight-ntwrk/compact-runtime";
+
+// --- Types ---
+
+interface MerklePath {
+  siblings: bigint[];
+  directions: boolean[];
+}
+
+interface TokenCommitment {
+  value: bigint;
+  owner_hash: bigint;
+  salt: bigint;
+}
+
+// --- Simple Merkle Tree ---
+
+class SimpleMerkleTree {
+  private leaves: bigint[];
+  private layers: bigint[][];
+
+  constructor(leaves: bigint[]) {
+    this.leaves = [...leaves];
+    this.layers = [leaves];
+    this.buildTree();
+  }
+
+  private hashPair(left: bigint, right: bigint): bigint {
+    return (left + right * 2n) % (2n ** 254n);
+  }
+
+  private buildTree(): void {
+    let currentLayer = this.leaves;
+    while (currentLayer.length > 1) {
+      const nextLayer: bigint[] = [];
+      for (let i = 0; i < currentLayer.length; i += 2) {
+        const left = currentLayer[i];
+        const right = i + 1 < currentLayer.length ? currentLayer[i + 1] : 0n;
+        nextLayer.push(this.hashPair(left, right));
+      }
+      this.layers.push(nextLayer);
+      currentLayer = nextLayer;
+    }
+  }
+
+  getRoot(): bigint {
+    return this.layers[this.layers.length - 1][0];
+  }
+
+  getLeaf(index: number): bigint {
+    return this.leaves[index] ?? 0n;
+  }
+
+  getProof(index: number): MerklePath {
+    const siblings: bigint[] = [];
+    const directions: boolean[] = [];
+    let currentIndex = index;
+    for (let layer = 0; layer < this.layers.length - 1; layer++) {
+      const isRight = currentIndex % 2 === 1;
+      const siblingIndex = isRight ? currentIndex - 1 : currentIndex + 1;
+      const sibling = this.layers[layer][siblingIndex] ?? 0n;
+      siblings.push(sibling);
+      directions.push(isRight);
+      currentIndex = Math.floor(currentIndex / 2);
+    }
+    return { siblings, directions };
+  }
+}
+
+// --- Off-Chain Data ---
+
+const tokenCommitments: TokenCommitment[] = [
+  { value: 100n, owner_hash: 0xdeadbeefn, salt: 42n },
+  { value: 200n, owner_hash: 0xcafebaben, salt: 43n },
+  { value: 300n, owner_hash: 0xfacefeedn, salt: 44n },
+  { value: 50n,  owner_hash: 0x12345678n, salt: 45n },
+];
+
+function commitToken(token: TokenCommitment): bigint {
+  return ((token.value + token.owner_hash * 2n) + token.salt * 2n) % (2n ** 254n);
+}
+
+const leafValues = tokenCommitments.map(commitToken);
+const merkleTree = new SimpleMerkleTree(leafValues);
+
+console.log(`[MerkleTree] Root: ${merkleTree.getRoot()}`);
+console.log(`[MerkleTree] Leaves: ${leafValues.length}`);
+
+// --- Witness Providers ---
+
+export const merkleWitnessProviders: WitnessProviders = {
+
+  /** Returns the leaf value at a given index. */
+  get_leaf_value: (index: bigint): bigint => {
+    const idx = Number(index);
+    const value = merkleTree.getLeaf(idx);
+    console.log(`[get_leaf_value] index=${idx} => ${value}`);
+    return value;
+  },
+
+  /** Returns the Merkle proof for a given leaf index. */
+  get_merkle_proof: (index: bigint): MerklePath => {
+    const idx = Number(index);
+    const proof = merkleTree.getProof(idx);
+    console.log(`[get_merkle_proof] index=${idx} => ${proof.siblings.length} siblings`);
+    return proof;
+  },
+
+  /** Returns the full token commitment at a given index. */
+  get_commitment: (index: bigint): TokenCommitment => {
+    const idx = Number(index);
+    const commitment = tokenCommitments[idx];
+    console.log(`[get_commitment] index=${idx} =>`, commitment);
+    return commitment ?? { value: 0n, owner_hash: 0n, salt: 0n };
+  },
+};
+
+// --- Demo ---
+
+function demo() {
+  console.log("\n=== Merkle Witness Provider Demo ===\n");
+
+  const leafIndex = 2n;
+
+  console.log("--- Getting leaf value ---");
+  const leaf = merkleWitnessProviders.get_leaf_value(leafIndex);
+
+  console.log("\n--- Getting Merkle proof ---");
+  const proof = merkleWitnessProviders.get_merkle_proof(leafIndex) as MerklePath;
+  console.log(`  Siblings (first 3): [${proof.siblings.slice(0, 3).join(", ")}...]`);
+  console.log(`  Directions (first 3): [${proof.directions.slice(0, 3).join(", ")}...]`);
+
+  console.log("\n--- Getting full commitment ---");
+  const commitment = merkleWitnessProviders.get_commitment(leafIndex) as TokenCommitment;
+  console.log(`  Value: ${commitment.value}, Owner: 0x${commitment.owner_hash.toString(16)}, Salt: ${commitment.salt}`);
+
+  console.log("\n--- Verification ---");
+  const root = merkleTree.getRoot();
+  console.log(`  Tree root: ${root}`);
+  console.log(`  (In the Compact circuit, root is recomputed from leaf + proof and compared to on-chain root)\n`);
+
+  console.log("=== Demo Complete ===");
+}
+
+if (require.main === module) {
+  demo();
+}
+
+export default merkleWitnessProviders;

--- a/tutorials/witnesses-in-depth/examples/merkle-witness.compact
+++ b/tutorials/witnesses-in-depth/examples/merkle-witness.compact
@@ -1,0 +1,94 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Merkle Witness Example — Midnight Compact
+// Demonstrates authenticated data inclusion proofs using Merkle witnesses
+
+// --- Constants ---
+
+const TREE_DEPTH: Uint<8> = 20;
+
+// --- Types ---
+
+struct MerklePath {
+  siblings: [Field; 20];
+  directions: [Boolean; 20];
+}
+
+struct TokenCommitment {
+  value: Field;
+  owner_hash: Field;
+  salt: Field;
+}
+
+// --- Witness Declarations ---
+
+witness get_leaf_value(index: Field): Field;
+witness get_merkle_proof(index: Field): MerklePath;
+witness get_commitment(index: Field): TokenCommitment;
+
+// --- Circuit Functions ---
+
+fn compute_root(leaf: Field, proof: MerklePath) -> Field {
+  let current: Field = leaf;
+  for i in 0..20 {
+    let sibling: Field = proof.siblings[i];
+    let is_right: Boolean = proof.directions[i];
+    if (is_right) {
+      current = hash_pair(sibling, current);
+    } else {
+      current = hash_pair(current, sibling);
+    }
+  }
+  return current;
+}
+
+fn hash_pair(left: Field, right: Field) -> Field {
+  return left + right * 2;
+}
+
+fn commit_token(token: TokenCommitment): Field {
+  return hash_pair(hash_pair(token.value, token.owner_hash), token.salt);
+}
+
+// --- Contract ---
+
+contract MerkleWitnessExample {
+
+  merkle_root: Field;
+  total_included: Field;
+
+  constructor(initial_root: Field) {
+    merkle_root = initial_root;
+    total_included = 0;
+  }
+
+  // Prove that a leaf exists in the Merkle tree
+  transition prove_inclusion(leaf_index: Field): Boolean {
+    let leaf: Field = get_leaf_value(leaf_index);
+    let proof: MerklePath = get_merkle_proof(leaf_index);
+    let computed_root: Field = compute_root(leaf, proof);
+    assert(computed_root == merkle_root, "Merkle proof invalid: root mismatch");
+    total_included = total_included + 1;
+    return true;
+  }
+
+  // Prove inclusion of a specific token commitment
+  transition prove_token_inclusion(leaf_index: Field, expected_value: Field): Boolean {
+    let commitment: TokenCommitment = get_commitment(leaf_index);
+    assert(commitment.value == expected_value, "Commitment value mismatch");
+    let leaf: Field = commit_token(commitment);
+    let proof: MerklePath = get_merkle_proof(leaf_index);
+    let computed_root: Field = compute_root(leaf, proof);
+    assert(computed_root == merkle_root, "Token not in tree");
+    total_included = total_included + 1;
+    return true;
+  }
+
+  // Update the Merkle root
+  transition update_root(new_root: Field) {
+    assert(new_root != merkle_root, "New root must differ from current");
+    merkle_root = new_root;
+  }
+}

--- a/tutorials/witnesses-in-depth/examples/witness-provider.ts
+++ b/tutorials/witnesses-in-depth/examples/witness-provider.ts
@@ -1,0 +1,110 @@
+// This file is part of contributor-hub.
+// Copyright (C) 2025 Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic Witness Provider — TypeScript Implementation
+// Implements witness providers for basic-witnesses.compact
+
+import { WitnessProviders, Field } from "@midnight-ntwrk/compact-runtime";
+
+// --- Simulated Off-Chain Database ---
+
+interface UserRecord {
+  balance: bigint;
+  nonce: bigint;
+  tier: number;
+}
+
+const balanceDatabase: Map<string, bigint> = new Map([
+  ["alice", 1000n],
+  ["bob", 500n],
+  ["charlie", 2500n],
+]);
+
+const recordDatabase: Map<string, UserRecord> = new Map([
+  ["alice", { balance: 1000n, nonce: 5n, tier: 2 }],
+  ["bob", { balance: 500n, nonce: 3n, tier: 1 }],
+  ["charlie", { balance: 2500n, nonce: 12n, tier: 3 }],
+]);
+
+// --- Helper ---
+
+function addressToString(addr: Uint8Array): string {
+  return Buffer.from(addr).toString("hex").slice(0, 16);
+}
+
+// --- Witness Providers ---
+
+export const basicWitnessProviders: WitnessProviders = {
+
+  /**
+   * Primitive Witness: get_balance(owner: Address): Field
+   * Returns the balance of the given address as a Field element.
+   */
+  get_balance: (owner: Uint8Array): bigint => {
+    const key = addressToString(owner);
+    const balance = balanceDatabase.get(key);
+    if (balance === undefined) {
+      console.warn(`[get_balance] No balance for ${key}, returning 0`);
+      return 0n;
+    }
+    console.log(`[get_balance] ${key} => ${balance}`);
+    return balance;
+  },
+
+  /**
+   * Composite Witness: get_user_record(addr: Address): UserRecord
+   * Returns a full user record (balance, nonce, tier) as a struct.
+   */
+  get_user_record: (addr: Uint8Array): UserRecord => {
+    const key = addressToString(addr);
+    const record = recordDatabase.get(key);
+    if (!record) {
+      console.warn(`[get_user_record] No record for ${key}, returning defaults`);
+      return { balance: 0n, nonce: 0n, tier: 0 };
+    }
+    console.log(`[get_user_record] ${key} =>`, record);
+    return record;
+  },
+
+  /**
+   * Argument-Free Witness: current_timestamp(): Uint<64>
+   * Returns the current timestamp. No arguments — value is context-dependent.
+   * NOTE: Prefer on-chain block timestamps in production for determinism.
+   */
+  current_timestamp: (): bigint => {
+    const timestamp = BigInt(Math.floor(Date.now() / 1000));
+    console.log(`[current_timestamp] => ${timestamp}`);
+    return timestamp;
+  },
+};
+
+// --- Demo Runner ---
+
+async function demo() {
+  console.log("=== Basic Witness Provider Demo ===\n");
+
+  const aliceAddr = new Uint8Array(Buffer.from("alice", "utf-8"));
+  const bobAddr = new Uint8Array(Buffer.from("bob", "utf-8"));
+
+  console.log("--- Primitive Witness: get_balance ---");
+  const aliceBalance = basicWitnessProviders.get_balance(aliceAddr);
+  const bobBalance = basicWitnessProviders.get_balance(bobAddr);
+  console.log(`Alice balance: ${aliceBalance}, Bob balance: ${bobBalance}\n`);
+
+  console.log("--- Composite Witness: get_user_record ---");
+  const aliceRecord = basicWitnessProviders.get_user_record(aliceAddr);
+  console.log(`Alice record:`, aliceRecord, "\n");
+
+  console.log("--- Argument-Free Witness: current_timestamp ---");
+  const now = basicWitnessProviders.current_timestamp();
+  console.log(`Current timestamp: ${now}\n`);
+
+  console.log("=== Demo Complete ===");
+}
+
+if (require.main === module) {
+  demo().catch(console.error);
+}
+
+export default basicWitnessProviders;

--- a/tutorials/witnesses-in-depth/witnesses-in-depth.md
+++ b/tutorials/witnesses-in-depth/witnesses-in-depth.md
@@ -1,0 +1,385 @@
+# Witnesses in Depth
+
+*A comprehensive guide to the Witness pattern in Midnight Network smart contracts*
+
+---
+
+## 1. Introduction
+
+In the Midnight Network, smart contracts operate within a zero-knowledge proof (ZKP) framework. Unlike traditional blockchains where all contract state is publicly visible on-chain, Midnight leverages zero-knowledge proofs to enable **data-protecting smart contracts** — contracts that can enforce business logic without revealing the underlying data.
+
+At the heart of this architecture lies the concept of **Witnesses**.
+
+A **witness** is a piece of data that is:
+1. **Computed off-chain** — it is never stored on the blockchain
+2. **Supplied to the ZK circuit** during proof generation
+3. **Used to validate** that a particular state transition is valid
+4. **Never revealed** to other participants or on-chain observers
+
+Think of a witness as the "secret ingredient" that proves you know something without showing what that something is. It is analogous to the "witness" concept in Bitcoin's SegWit or the "private inputs" in ZK-SNARKs, but with a richer type system and tooling support specific to the Midnight Compact language.
+
+### Why Witnesses Matter
+
+Without witnesses, a ZK contract would have no way to reference private state. Consider a simple token transfer: to prove that Alice has enough balance to send 10 tokens to Bob, the contract needs Alice's current balance. But Alice's balance is private — it should not appear on-chain. The **witness** provides Alice's balance to the circuit off-chain, and the circuit proves (via the ZKP) that the balance is sufficient, without ever revealing the actual number.
+
+This tutorial covers:
+- The **witness declaration pattern** in Compact
+- The **witness provider pattern** in TypeScript
+- All major **witness types**: primitive, composite, Merkle, and stateful
+- **Real-world use cases** and architectural best practices
+
+---
+
+## 2. The Witness Pattern
+
+The witness pattern in Midnight follows a **declare-then-provide** workflow that spans two layers:
+
+### Layer 1: Compact (On-Chain Contract)
+
+In the Compact smart contract language, you **declare** a witness using the `witness` keyword. This tells the compiler: "This value will be supplied externally during proof generation."
+
+```compact
+witness secret_balance(): Field;
+```
+
+This declaration creates a "hole" in the circuit. The ZK compiler knows a value will fill this hole, but it does not know the value at compile time. The circuit uses this value in its constraints, and during proof generation, the prover supplies the actual data.
+
+### Layer 2: TypeScript (Off-Chain Provider)
+
+The counterpart to a Compact witness declaration is a **witness provider** — a TypeScript function that computes and returns the witness value at proof-generation time.
+
+```typescript
+const witnessProviders: WitnessProviders = {
+  secret_balance: (): Field => {
+    return BigInt(userBalance);
+  }
+};
+```
+
+### The Full Lifecycle
+
+```
++---------------+     +-----------------+     +--------------+
+|  1. Declare   |     |  2. Implement   |     |  3. Generate |
+|  (Compact)    | --> |  (TypeScript)   | --> |  (Proof)     |
+|               |     |                 |     |              |
+|  witness f()  |     |  f: () => val   |     |  ZKP uses val|
++---------------+     +-----------------+     +--------------+
+```
+
+1. **Declare**: In Compact, you declare the witness function signature
+2. **Implement**: In TypeScript, you write the function that returns the value
+3. **Generate**: When creating a ZKP, the runtime calls your TypeScript function, receives the value, and feeds it into the circuit as a private input
+
+The circuit then uses the witness value to compute constraints. If the constraints are satisfied, the proof is valid. The witness value itself never appears in the proof or on-chain.
+
+---
+
+## 3. Witness Types
+
+Midnight supports several categories of witnesses, each suited to different use cases.
+
+### 3.1 Primitive Witnesses
+
+The simplest form: a witness that returns a single primitive value.
+
+```compact
+witness get_balance(owner: Address): Field;
+```
+
+**Use case**: Returning a private balance, a secret key, or a single numeric value.
+
+Primitive witnesses work with Compact's core types:
+- `Field` — an element of the proving system's field (most common)
+- `Uint<8>`, `Uint<16>`, `Uint<32>`, `Uint<64>` — unsigned integers of various widths
+- `Boolean` — a boolean value
+- `Bytes<N>` — fixed-length byte arrays
+
+### 3.2 Composite Witnesses
+
+A witness that returns a **struct** — multiple values grouped together.
+
+```compact
+struct UserRecord {
+  balance: Field;
+  nonce: Field;
+  tier: Uint<8>;
+}
+
+witness get_user_record(addr: Address): UserRecord;
+```
+
+**Use case**: When a single witness lookup needs to return multiple related values. This avoids multiple round-trips and keeps related data logically grouped.
+
+Composite witnesses are especially useful when the prover needs to supply a record from a database, where all fields are correlated and should be fetched atomically.
+
+### 3.3 Merkle Witnesses (Authenticated Witnesses)
+
+The most powerful witness type. A Merkle witness returns a value **along with a Merkle proof** that authenticates the value against a known root.
+
+```compact
+witness get_leaf_with_proof(index: Field): [MerkleWitness, Field];
+```
+
+**Use case**: Proving that a specific piece of data exists in a dataset (e.g., a UTXO set, an allowlist, or a state tree) without revealing the entire dataset.
+
+Merkle witnesses combine the witness pattern with authenticated data structures:
+
+```
+         Root (public)
+        /      \
+       H1      H2
+      / \     / \
+    H3  H4  H5  H6
+    |   |   |   |
+   v0  v1  v2  v3
+```
+
+To prove that `v2` is in the tree, the Merkle witness supplies `v2` plus the sibling hashes `[H6, H1]` (the "Merkle path"). The circuit reconstructs the root and checks that it matches the on-chain root.
+
+### 3.4 Stateful Witnesses
+
+A witness that maintains **internal state** across calls. The provider function is a closure that captures mutable state.
+
+```typescript
+let nonceCounter = 0;
+
+const witnessProviders = {
+  next_nonce: (): Field => {
+    nonceCounter++;
+    return BigInt(nonceCounter);
+  }
+};
+```
+
+**Use case**: Generating sequential nonces, counters, or any value that must change between calls. Stateful witnesses are essential for contracts that need to track ordering or prevent replay attacks.
+
+---
+
+## 4. Real-World Use Cases
+
+### 4.1 Private Token Transfers
+
+The canonical use case. A private token contract stores balances in a Merkle tree. Each leaf is a commitment to a user's balance.
+
+**Witnesses needed:**
+- `get_balance_commitment(owner): Field` — returns the user's balance commitment
+- `get_merkle_path(index): MerklePath` — returns the Merkle proof for the leaf
+- `get_nullifier_key(owner): Field` — returns a secret key used to derive nullifiers
+
+The circuit proves: "I know a balance that, when committed, produces a leaf in the Merkle tree with the known root, and that balance is >= the transfer amount."
+
+### 4.2 Voting and Governance
+
+A private voting system where each eligible voter can cast one vote without revealing their choice.
+
+**Witnesses needed:**
+- `get_voter_eligibility(addr): Field` — proves membership in the voter set
+- `get_vote_secret(): Field` — the voter's secret ballot
+- `get_merkle_proof(index): MerklePath` — authenticates eligibility
+
+### 4.3 Decentralized Identity (DID) Verification
+
+Proving attributes about your identity without revealing the identity itself.
+
+**Witnesses needed:**
+- `get_age(): Uint<8>` — proves you are over 18
+- `get_credential_commitment(): Field` — commitment to your credential
+- `get_issuer_signature(): Bytes<64>` — the issuer's signature on your credential
+
+### 4.4 Supply Chain Tracking
+
+Proving a product passed through a specific checkpoint without revealing the full supply chain route.
+
+**Witnesses needed:**
+- `get_checkpoint_id(): Field` — the checkpoint identifier
+- `get_route_proof(): MerklePath` — proof the checkpoint is in the authorized route set
+- `get_timestamp(): Uint<64>` — when the checkpoint was recorded
+
+---
+
+## 5. Implementation Deep Dive
+
+### 5.1 Compact Declaration Patterns
+
+**Pattern A: Input-Dependent Witness**
+
+The witness takes an argument that determines which value to return.
+
+```compact
+witness get_balance(owner: Address): Field;
+```
+
+The TypeScript provider receives `owner` and looks up their balance.
+
+**Pattern B: Argument-Free Witness**
+
+The witness takes no arguments — it returns a value determined entirely by the off-chain state.
+
+```compact
+witness current_timestamp(): Uint<64>;
+```
+
+Useful for values that are context-dependent (e.g., the current block time, a random nonce).
+
+**Pattern C: Witness with Complex Return**
+
+The witness returns a tuple or struct.
+
+```compact
+struct TransferProof {
+  balance_before: Field;
+  balance_after: Field;
+  merkle_path: MerklePath;
+}
+
+witness prepare_transfer(sender: Address, amount: Field): TransferProof;
+```
+
+This bundles everything the circuit needs for a single operation into one witness call.
+
+### 5.2 TypeScript Provider Patterns
+
+**Provider Registration**
+
+All witness providers are registered in a single object:
+
+```typescript
+import { WitnessProviders, Field } from "@midnight-ntwrk/compact-runtime";
+
+const witnessProviders: WitnessProviders = {
+  get_balance: (owner: Uint8Array): Field => {
+    const balance = localDatabase.getBalance(owner);
+    return BigInt(balance);
+  },
+
+  current_timestamp: (): Field => {
+    return BigInt(Math.floor(Date.now() / 1000));
+  },
+
+  prepare_transfer: (sender: Uint8Array, amount: bigint): TransferProof => {
+    const before = localDatabase.getBalance(sender);
+    const after = before - Number(amount);
+    const path = merkleTree.getPath(sender);
+    return { balance_before: BigInt(before), balance_after: BigInt(after), merkle_path: path };
+  }
+};
+```
+
+**Error Handling in Providers**
+
+Witness providers must be deterministic and must not fail unexpectedly. If a provider throws an error, proof generation fails. Best practices:
+
+- Always validate inputs before computing
+- Return default/zero values for missing data rather than throwing
+- Log errors for debugging
+
+```typescript
+get_balance: (owner: Uint8Array): Field => {
+  try {
+    const balance = localDatabase.getBalance(owner);
+    return BigInt(balance);
+  } catch (e) {
+    console.error("Failed to get balance:", e);
+    return 0n;
+  }
+}
+```
+
+### 5.3 Merkle Witness Implementation
+
+Merkle witnesses require careful implementation of the tree structure and proof generation.
+
+```typescript
+import { MerkleTree } from "@midnight-ntwrk/compact-runtime";
+
+// Build a Merkle tree from a dataset
+const leaves: Field[] = userData.map(u => u.commitment);
+const tree = new MerkleTree(leaves, HASH_FUNCTION);
+
+// Witness provider returns both the value and the proof
+get_leaf_with_proof: (index: bigint): [MerklePath, Field] => {
+  const leaf = tree.getLeaf(Number(index));
+  const path = tree.getPath(Number(index));
+  return [path, leaf];
+}
+```
+
+The circuit then reconstructs the root:
+
+```compact
+fn verify_inclusion(leaf: Field, path: MerklePath, root: Field) -> Boolean {
+  let computed_root = leaf;
+  for i in 0..TREE_DEPTH {
+    if path.directions[i] {
+      computed_root = hash(path.siblings[i], computed_root);
+    } else {
+      computed_root = hash(computed_root, path.siblings[i]);
+    }
+  }
+  return computed_root == root;
+}
+```
+
+---
+
+## 6. Best Practices
+
+### 6.1 Keep Witnesses Minimal
+
+Only request the data you need. Each witness value becomes a private input to the circuit, increasing proof size and generation time.
+
+**Anti-pattern**: One witness that returns an entire database record when you only need one field.
+
+**Pattern**: Separate witnesses for each piece of data, or a composite witness with only the needed fields.
+
+### 6.2 Deterministic Providers
+
+Witness providers must be **deterministic** — given the same inputs, they must always return the same output. Non-deterministic behavior (random numbers, timestamps that change) will cause proof verification to fail if the proof is re-verified later.
+
+For time-dependent values, use blockchain timestamps rather than `Date.now()`.
+
+### 6.3 Version Your Witnesses
+
+As your contract evolves, witness signatures may change. Version your witness providers:
+
+```typescript
+const witnessProvidersV1 = { /* ... */ };
+const witnessProvidersV2 = { /* ... */ };
+```
+
+### 6.4 Test Witnesses Independently
+
+Write unit tests for your witness providers separately from contract tests. This catches issues in data retrieval and computation logic before they surface as mysterious proof-generation failures.
+
+---
+
+## 7. Common Pitfalls
+
+- **Proof generation fails silently**: Witness provider returns wrong type. Solution: Ensure return types match Compact declarations exactly.
+- **Verification fails after successful generation**: Non-deterministic provider. Solution: Make providers pure functions of inputs + stable state.
+- **Merkle root mismatch**: Tree rebuilt with different ordering. Solution: Ensure consistent leaf ordering between tree build and witness lookup.
+- **High proof generation time**: Too many large witnesses. Solution: Minimize witness data; use Merkle proofs instead of returning full datasets.
+
+---
+
+## 8. Summary
+
+Witnesses are the cornerstone of data-protecting smart contracts on Midnight Network. They enable:
+
+- **Privacy**: Data stays off-chain; only proofs are published
+- **Flexibility**: Any off-chain data source can feed witnesses
+- **Security**: The ZK circuit enforces constraints on witness values without revealing them
+- **Composability**: Witnesses can be combined to build complex private protocols
+
+The declare-then-provide pattern (Compact declaration + TypeScript provider) creates a clean separation between on-chain logic and off-chain data management. By understanding the four witness types — primitive, composite, Merkle, and stateful — you can build anything from simple private tokens to complex multi-party protocols.
+
+### Next Steps
+
+1. Run the [code examples](./examples/) in this tutorial
+2. Read the [Midnight Compact Language Reference](https://docs.midnight.network/compact/)
+3. Build your own private contract and share it with the [Midnight community](https://discord.com/invite/midnightnetwork)
+
+---
+
+*This tutorial was contributed as part of [midnightntwrk/contributor-hub#291](https://github.com/midnightntwrk/contributor-hub/issues/291). Licensed under Apache 2.0.*


### PR DESCRIPTION
## Overview

This PR adds a comprehensive **Witnesses in Depth** tutorial to the `tutorials/` directory, addressing issue #291.

## What's Included

**Tutorial** (`tutorials/witnesses-in-depth/witnesses-in-depth.md` — 2000+ words):
- Introduction to witnesses in Midnight's ZK architecture
- The declare-then-provide pattern (Compact + TypeScript)
- Four witness types: primitive, composite, Merkle, and stateful
- Real-world use cases: private tokens, voting, DID, supply chain
- Implementation deep dive with code patterns
- Best practices and common pitfalls

**Index** (`tutorials/witnesses-in-depth/README.md`):
- Quick start guide, prerequisites, and links to all resources

**Code Examples** (6 files in `examples/`):
- `basic-witnesses.compact` + `witness-provider.ts` — Core witness patterns
- `merkle-witness.compact` + `merkle-witness-provider.ts` — Authenticated Merkle inclusion proofs
- `counter-witness.compact` + `counter-witness-provider.ts` — Stateful witness with closures

## Submission Checklist

- [x] Useful pull request description
- [x] Code examples provided with both Compact and TypeScript implementations
- [x] All code includes Apache 2.0 license headers
- [x] Tutorial is self-contained and beginner-friendly
- [x] Self-reviewed the diff
- [x] No new todos introduced

Closes #291