### PR TITLE
docs: Submit tutorial for Unshielded Token dApp (#328)

### DIFF
--- a/submissions/328/arthurus36-alt-submission.md
+++ b/submissions/328/arthurus36-alt-submission.md
@@ -1,0 +1,23 @@
+## Bounty Submission: [Tutorial] Building an Unshielded Token dApp with UI
+
+**GitHub Username:** @arthurus36-alt
+
+### Deliverables
+
+1. **Written Tutorial (Dev.to):**
+   [Building an Unshielded Token dApp on Midnight: A React & Compact Guide](https://dev.to/arthurus36/building-an-unshielded-token-dapp-on-midnight-a-react-compact-guide-2n4l)
+
+2. **Proof-of-Concept Code Repository:**
+   [github.com/arthurus36-alt/midnight-unshielded-dapp](https://github.com/arthurus36-alt/midnight-unshielded-dapp)
+
+### Summary of Implementation
+
+I have fully completed the requested tutorial covering end-to-end unshielded token operations on Midnight. 
+
+- **Compact Contract:** I wrote a standard `unshielded_token.compact` contract utilizing `mintUnshieldedToken`, `sendUnshielded`, and `receiveUnshielded`. The code strictly compiles without warnings.
+- **Frontend Integration:** Built a React application (`/frontend`) utilizing `@midnight-ntwrk/midnight-js` to connect to the Lace wallet, allowing users to mint, transfer, and read their unshielded balance directly from the UI.
+- **Written Content:** The 1,800-word Dev.to article walks through the exact architectural differences between shielded and unshielded states, explicitly highlighting the privacy trade-offs and when to use public ledgers on Midnight.
+
+All code has been tested against a local Docker stack and compiles flawlessly.
+
+Ready for review!


### PR DESCRIPTION
Closes #328

This PR contains the submission details for the Unshielded Token dApp Tutorial bounty.

### Deliverables included:
1. **Written Tutorial:** A comprehensive 1,800-word Dev.to article explaining Compact unshielded tokens, React integration, and the privacy trade-offs.
2. **Repository:** A fully working PoC repository with compilable Compact contracts and a functional React UI.

The submission is ready for review.